### PR TITLE
Fix shader path, meson doesn't include trailing slash in prefix

### DIFF
--- a/src/render.c
+++ b/src/render.c
@@ -35,7 +35,7 @@
 
 #define MAYBE_UNUSED __attribute__((unused))
 
-#define SHADER_PATH PREFIX "share/wayvnc/shaders"
+#define SHADER_PATH PREFIX "/share/wayvnc/shaders"
 
 enum {
 	ATTR_INDEX_POS = 0,


### PR DESCRIPTION
Fixes #11 