### PR TITLE
Fix keyboard shared memory, use memfd/SHM_ANON

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -93,6 +93,13 @@ if host_system == 'linux' and cc.has_header('sys/sdt.h')
 	config.set('HAVE_USDT', true)
 endif
 
+if cc.has_function('memfd_create')
+	config.set('HAVE_MEMFD', true)
+	config.set('HAVE_MEMFD_CREATE', true)
+elif cc.has_function('SYS_memfd_create', prefix : '#include <sys/syscall.h>')
+	config.set('HAVE_MEMFD', true)
+endif
+
 configure_file(
 	output: 'config.h',
 	configuration: config,

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -171,7 +171,7 @@ int keyboard_init(struct keyboard* self, const char* layout)
 
 	size_t keymap_len = strlen(keymap_string);
 
-	int keymap_fd = shm_alloc_fd(0);
+	int keymap_fd = shm_alloc_fd(keymap_len);
 	if (keymap_fd < 0)
 		goto fd_failure;
 


### PR DESCRIPTION
This fixes the wlroots-on-FreeBSD crash described in https://github.com/swaywm/wlroots/issues/2014 (`write` was returning 0 because the shm fd wasn't `ftruncate`d to size, your TODO check would've helped lol)

and while here: proper shared-memory-fd support with memfd :)