### PR TITLE
More keymap stuff

### DIFF
--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -170,15 +170,15 @@ int keyboard_init(struct keyboard* self, const char* layout)
 	if (!keymap_string)
 		goto keymap_string_failure;
 
-	size_t keymap_len = strlen(keymap_string) + 1;
+	size_t keymap_size = strlen(keymap_string) + 1;
 
-	int keymap_fd = shm_alloc_fd(keymap_len);
+	int keymap_fd = shm_alloc_fd(keymap_size);
 	if (keymap_fd < 0)
 		goto fd_failure;
 
 	int written = 0;
-	while (written < keymap_len) {
-		ssize_t ret = write(keymap_fd, keymap_string + written, keymap_len - written);
+	while (written < keymap_size) {
+		ssize_t ret = write(keymap_fd, keymap_string + written, keymap_size - written);
 		if (ret == -1 && errno == EINTR)
 			continue;
 		if (ret == -1)
@@ -190,7 +190,7 @@ int keyboard_init(struct keyboard* self, const char* layout)
 
 	zwp_virtual_keyboard_v1_keymap(self->virtual_keyboard,
 	                               WL_KEYBOARD_KEYMAP_FORMAT_XKB_V1,
-	                               keymap_fd, keymap_len);
+	                               keymap_fd, keymap_size);
 
 	close(keymap_fd);
 

--- a/src/keyboard.c
+++ b/src/keyboard.c
@@ -169,7 +169,7 @@ int keyboard_init(struct keyboard* self, const char* layout)
 	if (!keymap_string)
 		goto keymap_string_failure;
 
-	size_t keymap_len = strlen(keymap_string);
+	size_t keymap_len = strlen(keymap_string) + 1;
 
 	int keymap_fd = shm_alloc_fd(keymap_len);
 	if (keymap_fd < 0)


### PR DESCRIPTION
Continuing with the same place in the code again :)

when trying to add a check for the null byte to wlroots, I found out that wayvnc didn't send one, and it's supposed to, even though everything works anyway due to luck :D

see wlroots: https://github.com/swaywm/wlroots/blob/1fa9e0203b4192659a36ddd259c174569bc227d5/types/wlr_keyboard.c#L192

While here, deal with "TODO: Check that write finished writing everything", why not. (Short writes tested by changing the last `write` argument to `min(keymap_len - written, 420)` and observing syscalls.)