### PR TITLE
Unbreak build without libgbm

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -22,7 +22,6 @@
 #include <sys/mman.h>
 #include <libdrm/drm_fourcc.h>
 #include <wayland-client.h>
-#include <gbm.h>
 #include <pixman.h>
 
 #include "linux-dmabuf-unstable-v1.h"
@@ -31,6 +30,10 @@
 #include "buffer.h"
 #include "pixels.h"
 #include "config.h"
+
+#ifdef ENABLE_SCREENCOPY_DMABUF
+#include <gbm.h>
+#endif
 
 extern struct wl_shm* wl_shm;
 extern struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf;


### PR DESCRIPTION
Regressed by 3742dc7144a8 (made `gbm` in meson.build optional). From [error log](https://github.com/any1/wayvnc/files/4984087/wayvnc-0.2.0.log):
```c
../src/buffer.c:25:10: fatal error: 'gbm.h' file not found
#include <gbm.h>
         ^~~~~~~
```
https://github.com/any1/wayvnc/blob/800b0d6cb76ac647615d409e6214861333fd122b/src/main.c#L56-L57
