### PR TITLE
Silence -Wunused-function on FreeBSD < 13

### DIFF
--- a/src/shm.c
+++ b/src/shm.c
@@ -31,7 +31,7 @@ static inline int memfd_create(const char *name, unsigned int flags) {
 }
 #endif
 
-#ifndef HAVE_MEMFD
+#if !defined(HAVE_MEMFD) && !defined(__FreeBSD__)
 static void randname(char *buf)
 {
 	struct timespec ts;


### PR DESCRIPTION
Regressed by #31. From [build log](https://github.com/any1/wayvnc/files/4984140/wayvnc-0.2.0.log):
```c
../src/shm.c:35:13: warning: unused function 'randname' [-Wunused-function]
static void randname(char *buf)
            ^
```
