### PR TITLE
Add openSUSE Tumbleweed installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ pkg install wayvnc
 dnf install wayvnc
 ```
 
+### openSUSE Tumbleweed
+
+```
+zypper install wayvnc
+```
+
 ## Building
 ### Runtime Dependencies
  * aml


### PR DESCRIPTION
`wayvnc` is in the official openSUSE Tumbleweed repos and can be installed with a single command.