### PR TITLE
Add basic clipboard support

### DIFF
--- a/include/data-control.h
+++ b/include/data-control.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020 Scott Moreau
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <neatvnc.h>
+
+#include "wlr-data-control-unstable-v1.h"
+
+struct data_control {
+	struct wl_display* wl_display;
+	struct nvnc* server;
+	struct zwlr_data_control_manager_v1* manager;
+	struct zwlr_data_control_device_v1* device;
+	struct zwlr_data_control_source_v1* selection;
+	struct zwlr_data_control_source_v1* primary_selection;
+	struct zwlr_data_control_offer_v1* offer;
+	const char* mime_type;
+	char* cb_data;
+	size_t cb_len;
+};
+
+void data_control_init(struct data_control* self, struct wl_display* wl_display, struct nvnc* server, struct wl_seat* seat);
+void data_control_destroy(struct data_control* self);
+void data_control_to_clipboard(struct data_control* self, const char* text, size_t len);

--- a/meson.build
+++ b/meson.build
@@ -73,6 +73,7 @@ sources = [
 	'src/strlcpy.c',
 	'src/shm.c',
 	'src/screencopy.c',
+	'src/data-control.c',
 	'src/output.c',
 	'src/pointer.c',
 	'src/keyboard.c',

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -20,6 +20,7 @@ client_protocols = [
 	'virtual-keyboard-unstable-v1.xml',
 	'xdg-output-unstable-v1.xml',
 	'linux-dmabuf-unstable-v1.xml',
+	'wlr-data-control-unstable-v1.xml',
 ]
 
 client_protos_src = []

--- a/protocols/wlr-data-control-unstable-v1.xml
+++ b/protocols/wlr-data-control-unstable-v1.xml
@@ -1,0 +1,278 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_data_control_unstable_v1">
+  <copyright>
+    Copyright © 2018 Simon Ser
+    Copyright © 2019 Ivan Molodetskikh
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <description summary="control data devices">
+    This protocol allows a privileged client to control data devices. In
+    particular, the client will be able to manage the current selection and take
+    the role of a clipboard manager.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_data_control_manager_v1" version="2">
+    <description summary="manager to control data devices">
+      This interface is a manager that allows creating per-seat data device
+      controls.
+    </description>
+
+    <request name="create_data_source">
+      <description summary="create a new data source">
+        Create a new data source.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_data_control_source_v1"
+        summary="data source to create"/>
+    </request>
+
+    <request name="get_data_device">
+      <description summary="get a data device for a seat">
+        Create a data device that can be used to manage a seat's selection.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_data_control_device_v1"/>
+      <arg name="seat" type="object" interface="wl_seat"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_data_control_device_v1" version="2">
+    <description summary="manage a data device for a seat">
+      This interface allows a client to manage a seat's selection.
+
+      When the seat is destroyed, this object becomes inert.
+    </description>
+
+    <request name="set_selection">
+      <description summary="copy data to the selection">
+        This request asks the compositor to set the selection to the data from
+        the source on behalf of the client.
+
+        The given source may not be used in any further set_selection or
+        set_primary_selection requests. Attempting to use a previously used
+        source is a protocol error.
+
+        To unset the selection, set the source to NULL.
+      </description>
+      <arg name="source" type="object" interface="zwlr_data_control_source_v1"
+        allow-null="true"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this data device">
+        Destroys the data device object.
+      </description>
+    </request>
+
+    <event name="data_offer">
+      <description summary="introduce a new wlr_data_control_offer">
+        The data_offer event introduces a new wlr_data_control_offer object,
+        which will subsequently be used in either the
+        wlr_data_control_device.selection event (for the regular clipboard
+        selections) or the wlr_data_control_device.primary_selection event (for
+        the primary clipboard selections). Immediately following the
+        wlr_data_control_device.data_offer event, the new data_offer object
+        will send out wlr_data_control_offer.offer events to describe the MIME
+        types it offers.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_data_control_offer_v1"/>
+    </event>
+
+    <event name="selection">
+      <description summary="advertise new selection">
+        The selection event is sent out to notify the client of a new
+        wlr_data_control_offer for the selection for this device. The
+        wlr_data_control_device.data_offer and the wlr_data_control_offer.offer
+        events are sent out immediately before this event to introduce the data
+        offer object. The selection event is sent to a client when a new
+        selection is set. The wlr_data_control_offer is valid until a new
+        wlr_data_control_offer or NULL is received. The client must destroy the
+        previous selection wlr_data_control_offer, if any, upon receiving this
+        event.
+
+        The first selection event is sent upon binding the
+        wlr_data_control_device object.
+      </description>
+      <arg name="id" type="object" interface="zwlr_data_control_offer_v1"
+        allow-null="true"/>
+    </event>
+
+    <event name="finished">
+      <description summary="this data control is no longer valid">
+        This data control object is no longer valid and should be destroyed by
+        the client.
+      </description>
+    </event>
+
+    <!-- Version 2 additions -->
+
+    <event name="primary_selection" since="2">
+      <description summary="advertise new primary selection">
+        The primary_selection event is sent out to notify the client of a new
+        wlr_data_control_offer for the primary selection for this device. The
+        wlr_data_control_device.data_offer and the wlr_data_control_offer.offer
+        events are sent out immediately before this event to introduce the data
+        offer object. The primary_selection event is sent to a client when a
+        new primary selection is set. The wlr_data_control_offer is valid until
+        a new wlr_data_control_offer or NULL is received. The client must
+        destroy the previous primary selection wlr_data_control_offer, if any,
+        upon receiving this event.
+
+        If the compositor supports primary selection, the first
+        primary_selection event is sent upon binding the
+        wlr_data_control_device object.
+      </description>
+      <arg name="id" type="object" interface="zwlr_data_control_offer_v1"
+        allow-null="true"/>
+    </event>
+
+    <request name="set_primary_selection" since="2">
+      <description summary="copy data to the primary selection">
+        This request asks the compositor to set the primary selection to the
+        data from the source on behalf of the client.
+
+        The given source may not be used in any further set_selection or
+        set_primary_selection requests. Attempting to use a previously used
+        source is a protocol error.
+
+        To unset the primary selection, set the source to NULL.
+
+        The compositor will ignore this request if it does not support primary
+        selection.
+      </description>
+      <arg name="source" type="object" interface="zwlr_data_control_source_v1"
+        allow-null="true"/>
+    </request>
+
+    <enum name="error" since="2">
+      <entry name="used_source" value="1"
+        summary="source given to set_selection or set_primary_selection was already used before"/>
+    </enum>
+  </interface>
+
+  <interface name="zwlr_data_control_source_v1" version="1">
+    <description summary="offer to transfer data">
+      The wlr_data_control_source object is the source side of a
+      wlr_data_control_offer. It is created by the source client in a data
+      transfer and provides a way to describe the offered data and a way to
+      respond to requests to transfer the data.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_offer" value="1"
+        summary="offer sent after wlr_data_control_device.set_selection"/>
+    </enum>
+
+    <request name="offer">
+      <description summary="add an offered MIME type">
+        This request adds a MIME type to the set of MIME types advertised to
+        targets. Can be called several times to offer multiple types.
+
+        Calling this after wlr_data_control_device.set_selection is a protocol
+        error.
+      </description>
+      <arg name="mime_type" type="string"
+        summary="MIME type offered by the data source"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this source">
+        Destroys the data source object.
+      </description>
+    </request>
+
+    <event name="send">
+      <description summary="send the data">
+        Request for data from the client. Send the data as the specified MIME
+        type over the passed file descriptor, then close it.
+      </description>
+      <arg name="mime_type" type="string" summary="MIME type for the data"/>
+      <arg name="fd" type="fd" summary="file descriptor for the data"/>
+    </event>
+
+    <event name="cancelled">
+      <description summary="selection was cancelled">
+        This data source is no longer valid. The data source has been replaced
+        by another data source.
+
+        The client should clean up and destroy this data source.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="zwlr_data_control_offer_v1" version="1">
+    <description summary="offer to transfer data">
+      A wlr_data_control_offer represents a piece of data offered for transfer
+      by another client (the source client). The offer describes the different
+      MIME types that the data can be converted to and provides the mechanism
+      for transferring the data directly from the source client.
+    </description>
+
+    <request name="receive">
+      <description summary="request that the data is transferred">
+        To transfer the offered data, the client issues this request and
+        indicates the MIME type it wants to receive. The transfer happens
+        through the passed file descriptor (typically created with the pipe
+        system call). The source client writes the data in the MIME type
+        representation requested and then closes the file descriptor.
+
+        The receiving client reads from the read end of the pipe until EOF and
+        then closes its end, at which point the transfer is complete.
+
+        This request may happen multiple times for different MIME types.
+      </description>
+      <arg name="mime_type" type="string"
+        summary="MIME type desired by receiver"/>
+      <arg name="fd" type="fd" summary="file descriptor for data transfer"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this offer">
+        Destroys the data offer object.
+      </description>
+    </request>
+
+    <event name="offer">
+      <description summary="advertise offered MIME type">
+        Sent immediately after creating the wlr_data_control_offer object.
+        One event per offered MIME type.
+      </description>
+      <arg name="mime_type" type="string" summary="offered MIME type"/>
+    </event>
+  </interface>
+</protocol>

--- a/src/data-control.c
+++ b/src/data-control.c
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2020 Scott Moreau
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include "logging.h"
+#include "data-control.h"
+
+static void receive_data(void* data,
+	struct zwlr_data_control_offer_v1* zwlr_data_control_offer_v1)
+{
+	struct data_control* self = data;
+	char buf[4096];
+	FILE* mem_fp;
+	char* mem_data;
+	size_t mem_size = 0;
+	int pipe_fd[2];
+	int ret;
+
+	if (pipe(pipe_fd) == -1) {
+		log_error("pipe() failed: %m\n");
+		return;
+	}
+
+	zwlr_data_control_offer_v1_receive(zwlr_data_control_offer_v1, self->mime_type, pipe_fd[1]);
+	wl_display_flush(self->wl_display);
+	close(pipe_fd[1]);
+
+	mem_fp = open_memstream(&mem_data, &mem_size);
+	if (!mem_fp) {
+		log_error("open_memstream() failed: %m\n");
+		close(pipe_fd[0]);
+		return;
+	}
+
+	// TODO: Make this asynchronous
+	while ((ret = read(pipe_fd[0], &buf, sizeof(buf))) > 0)
+		if (fwrite(&buf, 1, ret, mem_fp) != ret)
+			break;
+
+	fclose(mem_fp);
+
+	if (mem_size)
+		nvnc_send_cut_text(self->server, mem_data, mem_size);
+
+	free(mem_data);
+	close(pipe_fd[0]);
+	zwlr_data_control_offer_v1_destroy(zwlr_data_control_offer_v1);
+}
+
+static void data_control_offer(void* data,
+	struct zwlr_data_control_offer_v1* zwlr_data_control_offer_v1,
+	const char* mime_type)
+{
+	struct data_control* self = data;
+
+	if (self->offer)
+		return;
+	if (strcmp(mime_type, self->mime_type) != 0) {
+		return;
+	}
+
+	self->offer = zwlr_data_control_offer_v1;
+}
+
+struct zwlr_data_control_offer_v1_listener data_control_offer_listener = {
+	data_control_offer
+};
+
+static void data_control_device_offer(void* data,
+	struct zwlr_data_control_device_v1* zwlr_data_control_device_v1,
+	struct zwlr_data_control_offer_v1* id)
+{
+	if (!id)
+		return;
+
+	zwlr_data_control_offer_v1_add_listener(id, &data_control_offer_listener, data);
+}
+
+static void data_control_device_selection(void* data,
+	struct zwlr_data_control_device_v1* zwlr_data_control_device_v1,
+	struct zwlr_data_control_offer_v1* id)
+{
+	struct data_control* self = data;
+	if (id && self->offer == id) {
+		receive_data(data, id);
+		self->offer = NULL;
+	}
+}
+
+static void data_control_device_finished(void* data,
+	struct zwlr_data_control_device_v1* zwlr_data_control_device_v1)
+{
+	zwlr_data_control_device_v1_destroy(zwlr_data_control_device_v1);
+}
+
+static void data_control_device_primary_selection(void* data,
+	struct zwlr_data_control_device_v1* zwlr_data_control_device_v1,
+	struct zwlr_data_control_offer_v1* id)
+{
+	struct data_control* self = data;
+	if (id && self->offer == id) {
+		receive_data(data, id);
+		self->offer = NULL;
+		return;
+	}
+}
+
+static struct zwlr_data_control_device_v1_listener data_control_device_listener = {
+	.data_offer = data_control_device_offer,
+	.selection = data_control_device_selection,
+	.finished = data_control_device_finished,
+	.primary_selection = data_control_device_primary_selection
+};
+
+static void
+data_control_source_send(void* data,
+	struct zwlr_data_control_source_v1* zwlr_data_control_source_v1,
+	const char* mime_type,
+	int32_t fd)
+{
+	struct data_control* self = data;
+	char* d = self->cb_data;
+	size_t len = self->cb_len;
+	int ret;
+
+	assert(d);
+
+	ret = write(fd, d, len);
+
+	if (ret < len)
+		log_error("write from clipboard incomplete\n");
+
+	close(fd);
+}
+
+static void data_control_source_cancelled(void* data,
+	struct zwlr_data_control_source_v1* zwlr_data_control_source_v1)
+{
+	struct data_control* self = data;
+
+	if (self->selection == zwlr_data_control_source_v1) {
+		self->selection = NULL;
+	}
+	if (self->primary_selection == zwlr_data_control_source_v1) {
+		self->primary_selection = NULL;
+	}
+	zwlr_data_control_source_v1_destroy(zwlr_data_control_source_v1);
+}
+
+struct zwlr_data_control_source_v1_listener data_control_source_listener = {
+	.send = data_control_source_send,
+	.cancelled = data_control_source_cancelled
+};
+
+static struct zwlr_data_control_source_v1* set_selection(struct data_control* self, bool primary) {
+	struct zwlr_data_control_source_v1* selection;
+	selection = zwlr_data_control_manager_v1_create_data_source(self->manager);
+	if (selection == NULL) {
+		log_error("zwlr_data_control_manager_v1_create_data_source() failed\n");
+		free(self->cb_data);
+		self->cb_data = NULL;
+		return NULL;
+	}
+
+	zwlr_data_control_source_v1_add_listener(selection, &data_control_source_listener, self);
+	zwlr_data_control_source_v1_offer(selection, self->mime_type);
+
+	if (primary)
+		zwlr_data_control_device_v1_set_primary_selection(self->device, selection);
+	else
+		zwlr_data_control_device_v1_set_selection(self->device, selection);
+
+	return selection;
+}
+
+void data_control_init(struct data_control* self, struct wl_display* wl_display, struct nvnc* server, struct wl_seat* seat)
+{
+	self->wl_display = wl_display;
+	self->server = server;
+	self->device = zwlr_data_control_manager_v1_get_data_device(self->manager, seat);
+	zwlr_data_control_device_v1_add_listener(self->device, &data_control_device_listener, self);
+	self->selection = NULL;
+	self->primary_selection = NULL;
+	self->cb_data = NULL;
+	self->cb_len = 0;
+	self->mime_type = "text/plain;charset=utf-8";
+}
+
+void data_control_destroy(struct data_control* self)
+{
+	if (self->selection) {
+		zwlr_data_control_source_v1_destroy(self->selection);
+		self->selection = NULL;
+	}
+	if (self->primary_selection) {
+		zwlr_data_control_source_v1_destroy(self->primary_selection);
+		self->primary_selection = NULL;
+	}
+	free(self->cb_data);
+
+	zwlr_data_control_manager_v1_destroy(self->manager);
+}
+
+void data_control_to_clipboard(struct data_control* self, const char* text, size_t len)
+{
+	if (!len) {
+		log_error("%s called with 0 length\n", __func__);
+		return;
+	}
+	free(self->cb_data);
+
+	self->cb_data = malloc(len);
+	if (!self->cb_data) {
+		log_error("OOM: %m\n");
+		return;
+	}
+
+	memcpy(self->cb_data, text, len);
+	self->cb_len = len;
+
+	// Set copy/paste buffer
+	self->selection = set_selection(self, false);
+	// Set highlight/middle_click buffer
+	self->primary_selection = set_selection(self, true);
+}


### PR DESCRIPTION
Uses wlr-data-control-unstable-v1 protocol to interface with the clipboard
making copy/paste of text possible.