### PR TITLE
Fixes

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -17,4 +17,3 @@
 #pragma once
 
 #define UDIV_UP(a, b) (((a) + (b) - 1) / (b))
-#define ALIGN_UP(n, a) (UDIV_UP(n, a) * a)

--- a/src/data-control.c
+++ b/src/data-control.c
@@ -100,8 +100,8 @@ static void receive_data(void* data,
 	ctx->offer = offer;
 	ctx->mem_fp = open_memstream(&ctx->mem_data, &ctx->mem_size);
 	if (!ctx->mem_fp) {
-		free(ctx);
 		close(ctx->fd);
+		free(ctx);
 		log_error("open_memstream() failed: %m\n");
 		return;
 	}
@@ -109,8 +109,8 @@ static void receive_data(void* data,
 	struct aml_handler* handler = aml_handler_new(ctx->fd, on_receive,
 			ctx, destroy_receive_context);
 	if (!handler) {
-		free(ctx);
 		close(ctx->fd);
+		free(ctx);
 		return;
 	}
 


### PR DESCRIPTION
Hi!
Some very small fixes found with PVS-Studio. The analyzer suggest to wrap parameters of the `ALIGN_UP` macro in parentheses, but seeing that it is unused, I removed it.