### PR TITLE
Don't free the front buffer if screencopy fails

### DIFF
--- a/src/screencopy.c
+++ b/src/screencopy.c
@@ -191,7 +191,8 @@ static void screencopy_failed(void* data,
 
 	screencopy__stop(self);
 
-	wv_buffer_pool_release(self->pool, self->front);
+	if (self->front)
+		wv_buffer_pool_release(self->pool, self->front);
 	self->front = NULL;
 
 	self->status = SCREENCOPY_FAILED;


### PR DESCRIPTION
It is possible for `screencopy_failed` to be called without
the front buffer ever being set, such as when the output is dpms-off.

Fixes #65