### PR TITLE
README: Add Debian dependency instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ dnf install -y meson gcc ninja-build pkg-config egl-wayland egl-wayland-devel \
 	wayland-devel gnutls-devel
 ```
 
+#### For Debian
+```
+sudo apt install gcc meson ninja-build pkg-config libpixman-1-dev \
+	libdrm-dev libxbcommon-dev libwayland-dev
+```
+
+
 The easiest way to satisfy the neatvnc and aml dependencies is to link to them
 in the subprojects directory:
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ dnf install -y meson gcc ninja-build pkg-config egl-wayland egl-wayland-devel \
 #### For Debian
 ```
 sudo apt install gcc meson ninja-build pkg-config libpixman-1-dev \
-	libdrm-dev libxbcommon-dev libwayland-dev
+	libdrm-dev libxkbcommon-dev libwayland-dev zlib1g-dev
 ```
 
 


### PR DESCRIPTION
I managed to compile wayvnc for Mobian on Pinephone and identified the Debian names of dependencies needed.

These can be added to the README for posterity.