### PR TITLE
Support UNIX domain sockets

### DIFF
--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -31,6 +31,10 @@ wayvnc - A VNC server for wlroots based Wayland compositors.
 *-p, --show-performance*
 	Show performance counters.
 
+*-u, --unix-socket*
+	Create a UNIX domain socket instead of TCP, treating the address as a
+	path.
+
 *-V, --version*
 	Show version info.
 


### PR DESCRIPTION
Makes use of the functionality added in
https://github.com/any1/neatvnc/pull/49 to support UNIX domain sockets
with a command line flag. This is what I was using to test that pull request, so it makes sense to open this now that it has been accepted. 

I have read and understood CONTRIBUTING.md and its associated documents.