### PR TITLE
Screencopy clip regions

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -38,6 +38,7 @@ enum wv_buffer_type {
 struct wv_buffer {
 	enum wv_buffer_type type;
 	TAILQ_ENTRY(wv_buffer) link;
+	LIST_ENTRY(wv_buffer) registry_link;
 
 	struct wl_buffer* wl_buffer;
 
@@ -47,7 +48,8 @@ struct wv_buffer {
 	uint32_t format;
 	bool y_inverted;
 
-	struct pixman_region16 damage;
+	struct pixman_region16 frame_damage;
+	struct pixman_region16 buffer_damage;
 
 	/* The following is only applicable to DMABUF */
 	struct gbm_bo* bo;
@@ -85,3 +87,5 @@ void wv_buffer_pool_resize(struct wv_buffer_pool* pool, enum wv_buffer_type,
 struct wv_buffer* wv_buffer_pool_acquire(struct wv_buffer_pool* pool);
 void wv_buffer_pool_release(struct wv_buffer_pool* pool,
 		struct wv_buffer* buffer);
+
+void wv_buffer_registry_damage_all(struct pixman_region16* region);

--- a/protocols/wlr-screencopy-unstable-v1.xml
+++ b/protocols/wlr-screencopy-unstable-v1.xml
@@ -38,7 +38,7 @@
     interface version number is reset.
   </description>
 
-  <interface name="zwlr_screencopy_manager_v1" version="3">
+  <interface name="zwlr_screencopy_manager_v1" version="4">
     <description summary="manager to inform clients and begin capturing">
       This object is a manager which offers requests to start capturing from a
       source.
@@ -80,7 +80,7 @@
     </request>
   </interface>
 
-  <interface name="zwlr_screencopy_frame_v1" version="3">
+  <interface name="zwlr_screencopy_frame_v1" version="4">
     <description summary="a frame ready for copy">
       This object represents a single frame.
 
@@ -228,5 +228,29 @@
         types, and send a "copy" request.
       </description>
     </event>
+
+    <!-- Version 4 additions -->
+    <request name="set_clip_region" since="4">
+      <description summary="set clip region">
+        Sets the clip region for the subsequent copy request. This tells the
+        compositor that it needn't copy outside the given region. The default
+        clip region contains the whole frame.
+      </description>
+      <arg name="x" type="uint" summary="region x coordinates"/>
+      <arg name="y" type="uint" summary="region y coordinates"/>
+      <arg name="width" type="uint" summary="region width"/>
+      <arg name="height" type="uint" summary="region height"/>
+    </request>
+
+    <request name="add_clip_region" since="4">
+      <description summary="add box to clip region">
+        Adds the given box to the clip region. This can be used to compose a
+        more fine grained region.
+      </description>
+      <arg name="x" type="uint" summary="region x coordinates"/>
+      <arg name="y" type="uint" summary="region y coordinates"/>
+      <arg name="width" type="uint" summary="region width"/>
+      <arg name="height" type="uint" summary="region height"/>
+    </request>
   </interface>
 </protocol>

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -39,6 +39,10 @@ extern struct wl_shm* wl_shm;
 extern struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf;
 extern struct gbm_device* gbm_device;
 
+LIST_HEAD(wv_buffer_list, wv_buffer);
+
+static struct wv_buffer_list buffer_registry;
+
 enum wv_buffer_type wv_buffer_get_available_types(void)
 {
 	enum wv_buffer_type type = 0;
@@ -90,7 +94,10 @@ struct wv_buffer* wv_buffer_create_shm(int width,
 	if (!self->wl_buffer)
 		goto shm_failure;
 
-	pixman_region_init(&self->damage);
+	pixman_region_init(&self->frame_damage);
+	pixman_region_init_rect(&self->buffer_damage, 0, 0, width, height);
+
+	LIST_INSERT_HEAD(&buffer_registry, self, registry_link);
 
 	close(fd);
 	return self;
@@ -148,6 +155,8 @@ static struct wv_buffer* wv_buffer_create_dmabuf(int width, int height,
 	if (!self->wl_buffer)
 		goto buffer_failure;
 
+	LIST_INSERT_HEAD(&buffer_registry, self, registry_link);
+
 	return self;
 
 buffer_failure:
@@ -196,8 +205,10 @@ static void wv_buffer_destroy_dmabuf(struct wv_buffer* self)
 
 void wv_buffer_destroy(struct wv_buffer* self)
 {
-	pixman_region_fini(&self->damage);
+	pixman_region_fini(&self->buffer_damage);
+	pixman_region_fini(&self->frame_damage);
 	wv_buffer_unmap(self);
+	LIST_REMOVE(self, registry_link);
 
 	switch (self->type) {
 	case WV_BUFFER_SHM:
@@ -275,8 +286,8 @@ void wv_buffer_unmap(struct wv_buffer* self)
 void wv_buffer_damage_rect(struct wv_buffer* self, int x, int y, int width,
 		int height)
 {
-	pixman_region_union_rect(&self->damage, &self->damage, x, y, width,
-			height);
+	pixman_region_union_rect(&self->frame_damage, &self->frame_damage, x, y,
+			width, height);
 }
 
 void wv_buffer_damage_whole(struct wv_buffer* self)
@@ -286,7 +297,7 @@ void wv_buffer_damage_whole(struct wv_buffer* self)
 
 void wv_buffer_damage_clear(struct wv_buffer* self)
 {
-	pixman_region_clear(&self->damage);
+	pixman_region_clear(&self->frame_damage);
 }
 
 struct wv_buffer_pool* wv_buffer_pool_create(enum wv_buffer_type type,
@@ -390,4 +401,12 @@ void wv_buffer_pool_release(struct wv_buffer_pool* pool,
 	} else {
 		wv_buffer_destroy(buffer);
 	}
+}
+
+void wv_buffer_registry_damage_all(struct pixman_region16* region)
+{
+	struct wv_buffer *buffer;
+	LIST_FOREACH(buffer, &buffer_registry, registry_link)
+		pixman_region_union(&buffer->buffer_damage,
+				&buffer->buffer_damage, region);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -663,7 +663,7 @@ void wayvnc_process_frame(struct wayvnc* self)
 
 	self->n_frames_captured++;
 	self->damage_area_sum +=
-		calculate_region_area(&self->screencopy.back->damage);
+		calculate_region_area(&self->screencopy.back->frame_damage);
 
 	DTRACE_PROBE(wayvnc, refine_damage_start);
 
@@ -671,7 +671,7 @@ void wayvnc_process_frame(struct wayvnc* self)
 	pixman_region_init(&txdamage);
 	pixman_region_init(&refined);
 	damage_refine(&self->damage_refinery, &refined,
-			&self->screencopy.back->damage,
+			&self->screencopy.back->frame_damage,
 			self->screencopy.back);
 	wv_region_transform(&txdamage, &refined,
 			self->selected_output->transform,


### PR DESCRIPTION
This introduces buffer damage tracking for screencopy buffers, which promises to reduce copying and therefore improve performance.