### PR TITLE
Function without virtual keyboard, mouse protocol

### DIFF
--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -35,6 +35,10 @@ wayvnc - A VNC server for wlroots based Wayland compositors.
 	Create a UNIX domain socket instead of TCP, treating the address as a
 	path.
 
+*-d, --disable-input*
+	Disable all remote input. This allows using wayvnc without compositor
+	support of virtual mouse / keyboard protocols.
+
 *-V, --version*
 	Show version info.
 


### PR DESCRIPTION
Some compositors have a working screencopy protocol implementation but
are missing virtual keyboard and/or virtual mouse protocols. On those
compositors, don't just outright fail, instead work as view-only mode.
This is useful for using a different system (like a tablet) as
additional screen without the system providing any kind of input.

I did not dive deep into wayvnc and its possible this patch is not complete.
It has been tested by using Remmina and some Android client to send input and wayvnc did not crash.
This patch started as a quick hack to get an additional remote screen working with [labwc](https://github.com/labwc/labwc) but I thought it may be relevant to others as well. Feel free to just close this PR if it doesn't match your expectations.

 I have read and understood CONTRIBUTING.md ~~and its associated documents~~.