### PR TITLE
Add meson subproject wraps for aml and neatvnc

### DIFF
--- a/subprojects/aml.wrap
+++ b/subprojects/aml.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/any1/aml.git
+revision = master

--- a/subprojects/neatvnc.wrap
+++ b/subprojects/neatvnc.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/any1/neatvnc.git
+revision = master


### PR DESCRIPTION
Makes compiling as easy as:
meson build_dir && meson compile -C build_dir