### PR TITLE
meson: use NDEBUG in release like b_ndebug=if-release

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ if git.found()
 	endif
 endif
 
-if buildtype != 'debug' and buildtype != 'debugoptimized'
+if buildtype == 'release'
 	c_args += '-DNDEBUG'
 endif
 


### PR DESCRIPTION
Meson also offers [`b_ndebug=if-release`](https://mesonbuild.com/Builtin-options.html#base-options), but right now, [`default_options` are ignored in subprojects](https://github.com/mesonbuild/meson/issues/6728).