### PR TITLE
Support VSOCK sockets

### DIFF
--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -42,6 +42,10 @@ wayvnc - A VNC server for wlroots based Wayland compositors.
 	Create a UNIX domain socket instead of TCP, treating the address as a
 	path.
 
+*-w, --vsock-socket*
+	Create a VSOCK socket instead of a UNIX domain socket, treating the
+	address as the CID.
+
 *-d, --disable-input*
 	Disable all remote input. This allows using wayvnc without compositor
 	support of virtual mouse / keyboard protocols.


### PR DESCRIPTION
Extends the UNIX domain socket support
introduced in:
https://github.com/any1/wayvnc/commit/81192ac74df316e0faf7bc2f985741f701db753d

Sample usage:
wayvnc --max-fps=200 --seat=seat0 --gpu --output=HEADLESS-1 **--vsock-socket 0xffffffff** 5900

Discussion:
https://github.com/any1/wayvnc/issues/144