### PR TITLE
chore(wrap): use wrap to manager subprojects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
+.cache
 build
-subprojects
+#subprojects
 *.swp
 .clang_complete
 .ycm_extra_conf.py
 perf.*
 *.pem
 .vimrc
+/subprojects/**/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ GitHub [discussion forum](https://github.com/any1/wayvnc/discussions) for the
 project.
 
 ## Installing
-```
+```bash
 # Arch Linux
 pacman -S wayvnc
 
@@ -50,12 +50,12 @@ xbps-install wayvnc
  * pkg-config
 
 #### For Arch Linux
-```
+```bash
 pacman -S base-devel libglvnd libxkbcommon pixman gnutls
 ```
 
 #### For Fedora 31
-```
+```bash
 dnf install -y meson gcc ninja-build pkg-config egl-wayland egl-wayland-devel \
 	mesa-libEGL-devel mesa-libEGL libwayland-egl libglvnd-devel \
 	libglvnd-core-devel libglvnd mesa-libGLES-devel mesa-libGLES \
@@ -64,12 +64,12 @@ dnf install -y meson gcc ninja-build pkg-config egl-wayland egl-wayland-devel \
 ```
 
 #### For Debian (unstable / testing)
-```
+```bash
 apt build-dep wayvnc
 ```
 The easiest way to satisfy the neatvnc and aml dependencies is to link to them
 in the subprojects directory:
-```
+```bash
 git clone https://github.com/any1/wayvnc.git
 git clone https://github.com/any1/neatvnc.git
 git clone https://github.com/any1/aml.git

--- a/meson.build
+++ b/meson.build
@@ -56,16 +56,16 @@ neatvnc_project = subproject(
 )
 
 aml_project = subproject('aml', required: false)
-if aml_project.found()
-	aml = aml_project.get_variable('aml_dep')
-else
+if get_option('neatvncSystem')
 	aml = dependency('aml')
+else
+	aml = aml_project.get_variable('aml_dep')
 endif
 
-if neatvnc_project.found()
-	neatvnc = neatvnc_project.get_variable('neatvnc_dep')
-else
+if get_option('amlSystem')
 	neatvnc = dependency('neatvnc', version: neatvnc_version)
+else
+	neatvnc = neatvnc_project.get_variable('neatvnc_dep')
 endif
 
 inc = include_directories('include')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,7 @@ option('man-pages', type: 'feature', value: 'auto',
 	description: 'Generate and install man pages')
 option('systemtap', type: 'boolean', value: false,
 	description: 'Enable tracing using sdt')
+option('neatvncSystem', type : 'boolean', value : false,
+  description: 'Use System neatvnc dependences')
+option('amlSystem', type : 'boolean', value : false,
+  description: 'Use System aml dependences')

--- a/subprojects/aml.wrap
+++ b/subprojects/aml.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url =  https://github.com/any1/aml.git
+revision = master 
+depth = 1

--- a/subprojects/neatvnc.wrap
+++ b/subprojects/neatvnc.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url =  https://github.com/any1/neatvnc.git
+revision = master 
+depth = 1


### PR DESCRIPTION
If use wrap file , then we do not need to clone by ourself

As the project is using meson, meson can use wrap to manager subprojects, then we need not to use clone anymore

Log: use wrap file to manager subprojects
