### PR TITLE
main: Prevent capture restart if idle

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -614,6 +614,9 @@ void on_output_dimension_change(struct output* output)
 	struct wayvnc* self = output->userdata;
 	assert(self->selected_output == output);
 
+	if (self->nr_clients == 0)
+		return;
+
 	nvnc_log(NVNC_LOG_DEBUG, "Output dimensions changed. Restarting frame capturer...");
 
 	screencopy_stop(&self->screencopy);


### PR DESCRIPTION
This prevents restarting the capture on dimension change when idle.
Previously the capture was running after the dimensions had changed
which caused starting the capture once a client connects to fail.

Fixes #152