### PR TITLE
More INFO-level logging

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -534,6 +534,10 @@ int init_nvnc(struct wayvnc* self, const char* addr, uint16_t port, bool is_unix
 		nvnc_log(NVNC_LOG_ERROR, "Failed to bind to address");
 		return -1;
 	}
+	if (is_unix)
+		nvnc_log(NVNC_LOG_INFO, "Listening for connections on %s", addr);
+	else
+		nvnc_log(NVNC_LOG_INFO, "Listening for connections on %s:%d", addr, port);
 
 	self->nvnc_display = nvnc_display_new(0, 0);
 	if (!self->nvnc_display)

--- a/src/main.c
+++ b/src/main.c
@@ -225,6 +225,8 @@ static void registry_remove(void* data, struct wl_registry* registry,
 
 	struct output* out = output_find_by_id(&self->outputs, id);
 	if (out) {
+		nvnc_log(NVNC_LOG_INFO, "Output %s went away", out->name);
+
 		wl_list_remove(&out->link);
 		output_destroy(out);
 
@@ -238,6 +240,7 @@ static void registry_remove(void* data, struct wl_registry* registry,
 
 	struct seat* seat = seat_find_by_id(&self->seats, id);
 	if (seat) {
+		nvnc_log(NVNC_LOG_INFO, "Seat %s went away", seat->name);
 		wl_list_remove(&seat->link);
 		seat_destroy(seat);
 

--- a/src/main.c
+++ b/src/main.c
@@ -847,6 +847,21 @@ void parse_keyboard_option(struct wayvnc* self, char* arg)
 	self->kb_layout = arg;
 }
 
+void log_selected_output(struct wayvnc* self)
+{
+	nvnc_log(NVNC_LOG_INFO, "Capturing output %s",
+			self->selected_output->name);
+	struct output* output;
+	wl_list_for_each(output, &self->outputs, link) {
+		bool this_output = (output->id == self->selected_output->id);
+		nvnc_log(NVNC_LOG_INFO, "%s %s %dx%d+%dx%d",
+				this_output ? ">>" : "--",
+				output->description,
+				output->width, output->height,
+				output->x, output->y);
+	}
+}
+
 static int log_level_from_string(const char* str)
 {
 	if (0 == strcmp(str, "quiet")) return NVNC_LOG_PANIC;
@@ -1045,6 +1060,7 @@ int main(int argc, char* argv[])
 	self.screencopy.wl_output = out->wl_output;
 	self.screencopy.rate_limit = max_rate;
 	self.screencopy.enable_linux_dmabuf = enable_gpu_features;
+	log_selected_output(&self);
 
 	if (self.keyboard_manager) {
 		self.keyboard_backend.virtual_keyboard =

--- a/src/main.c
+++ b/src/main.c
@@ -426,6 +426,7 @@ void wayvnc_exit(struct wayvnc* self)
 
 void on_signal(void* obj)
 {
+	nvnc_log(NVNC_LOG_WARNING, "Received termination signal. Shutting down.");
 	struct wayvnc* self = aml_get_userdata(obj);
 	wayvnc_exit(self);
 }

--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -62,6 +62,14 @@ running Wayland session, creates virtual input devices and exposes a single
 display via the RFB protocol. The Wayland session may be a headless one, so it
 is also possible to run wayvnc without a physical display attached.
 
+## MULTIPLE OUTPUTS
+
+If the Wayland session consists of  multiple outputs, only one will be captured.
+By default this will be the first one, but can be specified by the _-o_ command
+line argument. The argument accepts the short name such as _eDP-1_ or _DP-4_.
+Running wayvnc in verbose mode (_-v_) will display the names of all outputs on
+startup.
+
 # CONFIGURATION
 
 wayvnc searches for a config file in the location


### PR DESCRIPTION
Adds more output to verbose mode, including:
- Log the listening address and port
- Log removal of seats and outputs
- Add manpage section about multiple outputs
- Log signal handler
- Log output selection and list of outputs

I have (now) read and understood CONTRIBUTING.md and its associated documents.