### PR TITLE
Multi-output: part 1 - internal functions to cycle between outputs

### DIFF
--- a/include/output.h
+++ b/include/output.h
@@ -60,6 +60,14 @@ struct output* output_find_by_id(struct wl_list* list, uint32_t id);
 struct output* output_find_by_name(struct wl_list* list, const char* name);
 struct output* output_first(struct wl_list* list);
 
+enum output_cycle_direction {
+	OUTPUT_CYCLE_FORWARD,
+	OUTPUT_CYCLE_REVERSE,
+};
+struct output* output_cycle(const struct wl_list* list,
+		const struct output* current,
+		enum output_cycle_direction);
+
 uint32_t output_get_transformed_width(const struct output* self);
 uint32_t output_get_transformed_height(const struct output* self);
 

--- a/src/main.c
+++ b/src/main.c
@@ -227,13 +227,18 @@ static void registry_remove(void* data, struct wl_registry* registry,
 
 	struct output* out = output_find_by_id(&self->outputs, id);
 	if (out) {
-		nvnc_log(NVNC_LOG_INFO, "Output %s went away", out->name);
+		if (out == self->selected_output) {
+			nvnc_log(NVNC_LOG_WARNING, "Selected output %s went away",
+					out->name);
+			switch_to_prev_output(self);
+		} else
+			nvnc_log(NVNC_LOG_INFO, "Output %s went away", out->name);
 
 		wl_list_remove(&out->link);
 		output_destroy(out);
 
 		if (out == self->selected_output) {
-			nvnc_log(NVNC_LOG_ERROR, "Selected output went away. Exiting...");
+			nvnc_log(NVNC_LOG_ERROR, "No fallback outputs left. Exiting...");
 			wayvnc_exit(self);
 		}
 

--- a/src/output.c
+++ b/src/output.c
@@ -285,3 +285,20 @@ struct output* output_first(struct wl_list* list)
 
 	return output;
 }
+
+struct output* output_cycle(const struct wl_list* list,
+		const struct output* current,
+		enum output_cycle_direction direction)
+{
+	const struct wl_list* iter = current ? &current->link : list;
+	iter = (direction == OUTPUT_CYCLE_FORWARD) ?
+		iter->next : iter->prev;
+	if (iter == list) {
+		if (wl_list_empty(list))
+			return NULL;
+		iter = (direction == OUTPUT_CYCLE_FORWARD) ?
+			iter->next : iter->prev;
+	}
+	struct output* output;
+	return wl_container_of(iter, output, link);
+}


### PR DESCRIPTION
In support of multi-output displays (#112), this changeset does some internal refactoring to support switching capture and pointer input to other outputs while a client is connected.

I have read and understood CONTRIBUTING.md and its associated documents.
