### PR TITLE
wayvncctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ xbps-install wayvnc
  * neatvnc
  * pam (optional)
  * pixman
+ * jansson
 
 ### Build Dependencies
  * GCC
@@ -51,7 +52,7 @@ xbps-install wayvnc
 
 #### For Arch Linux
 ```
-pacman -S base-devel libglvnd libxkbcommon pixman gnutls
+pacman -S base-devel libglvnd libxkbcommon pixman gnutls jansson
 ```
 
 #### For Fedora 31
@@ -60,7 +61,7 @@ dnf install -y meson gcc ninja-build pkg-config egl-wayland egl-wayland-devel \
 	mesa-libEGL-devel mesa-libEGL libwayland-egl libglvnd-devel \
 	libglvnd-core-devel libglvnd mesa-libGLES-devel mesa-libGLES \
 	libxkbcommon-devel libxkbcommon libwayland-client libwayland \
-	wayland-devel gnutls-devel
+	wayland-devel gnutls-devel jansson-devel       
 ```
 
 #### For Debian (unstable / testing)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ dnf install -y meson gcc ninja-build pkg-config egl-wayland egl-wayland-devel \
 	mesa-libEGL-devel mesa-libEGL libwayland-egl libglvnd-devel \
 	libglvnd-core-devel libglvnd mesa-libGLES-devel mesa-libGLES \
 	libxkbcommon-devel libxkbcommon libwayland-client libwayland \
-	wayland-devel gnutls-devel jansson-devel       
+	wayland-devel gnutls-devel jansson-devel
 ```
 
 #### For Debian (unstable / testing)
@@ -130,3 +130,44 @@ password=p455w0rd
 private_key_file=/path/to/key.pem
 certificate_file=/path/to/cert.pem
 ```
+
+### wayvncctl control socket
+
+To facilitate runtime interaction and control, wayvnc opens a unix domain socket
+at *$XDG_RUNTIME_DIR*/wayvncctl (or a fallback of /tmp/wayvncctl-*$UID*). A
+client can connect and exchange json-formatted IPC messages to query and control
+the running wayvnc instance.
+
+Use the `wayvncctl` utility to interact with this control socket from the
+command line.
+
+The `help` command can interactively query the available IPC commands:
+
+```
+$ wayvncctl help
+{
+    "commands": [
+        "help",
+        "version",
+        "set-output",
+	...
+    ]
+}
+```
+
+```
+$ wayvncctl help command=help
+{
+    "help": {
+        "description": "List all commands, or show usage of a specific command",
+        "params": [
+            {
+                "command": "The command to show (optional)"
+            }
+        ]
+    }
+}
+```
+
+See the `wayvnc(1)` manpage for an in-depth description of the IPC protocol and
+the available commands.

--- a/include/ctl-client.h
+++ b/include/ctl-client.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Andri Yngvason
+ * Copyright (c) 2022 Jim Ramsay
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -16,12 +16,16 @@
 
 #pragma once
 
-#include <sys/types.h>
+#include <stdbool.h>
 
-#define UDIV_UP(a, b) (((a) + (b) - 1) / (b))
+struct ctl_client;
 
-extern const char* wayvnc_version;
+void ctl_client_debug_log(bool enable);
 
-const char* default_ctl_socket_path();
+struct ctl_client* ctl_client_new(const char* socket_path, void* userdata);
+void ctl_client_destroy(struct ctl_client*);
+void* ctl_client_userdata(struct ctl_client*);
 
-void advance_read_buffer(char (*buffer)[], size_t* current_len, size_t advance_by);
+
+int ctl_client_run_command(struct ctl_client* self,
+		int argc, char* argv[]);

--- a/include/ctl-client.h
+++ b/include/ctl-client.h
@@ -26,6 +26,7 @@ struct ctl_client* ctl_client_new(const char* socket_path, void* userdata);
 void ctl_client_destroy(struct ctl_client*);
 void* ctl_client_userdata(struct ctl_client*);
 
+#define PRINT_JSON 0x00000001
 
 int ctl_client_run_command(struct ctl_client* self,
-		int argc, char* argv[]);
+		int argc, char* argv[], unsigned flags);

--- a/include/ctl-server.h
+++ b/include/ctl-server.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Jim Ramsay
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include "output.h"
+#include <wayland-client.h>
+
+struct ctl;
+struct cmd_response;
+
+struct ctl_server_actions {
+	void* userdata;
+	struct cmd_response* (*on_output_cycle)(struct ctl*,
+			enum output_cycle_direction direction);
+	struct cmd_response* (*on_output_switch)(struct ctl*,
+			const char* output_name);
+};
+
+const char* default_ctl_socket_path();
+
+struct ctl* ctl_server_new(const char* socket_path,
+		const struct ctl_server_actions* actions);
+void ctl_server_destroy(struct ctl*);
+void* ctl_server_userdata(struct ctl*);
+
+struct cmd_response* cmd_ok(void);
+struct cmd_response* cmd_failed(const char* fmt, ...);

--- a/include/json-ipc.h
+++ b/include/json-ipc.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022 Jim Ramsay
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#pragma once
+
+#include <jansson.h>
+
+struct jsonipc_request {
+	const char* method;
+	json_t* params;
+	json_t* id;
+
+	json_t* json;
+};
+
+#define IPC_CODE_SUCCESS 0
+
+struct jsonipc_error {
+	int code;
+	json_t* data;
+};
+
+#define JSONIPC_ERR_INIT {0,NULL}
+
+struct jsonipc_response {
+	int code;
+	json_t* data;
+	json_t* id;
+
+	json_t* json;
+};
+
+void jsonipc_error_set_new(struct jsonipc_error*, int code, json_t* data);
+void jsonipc_error_printf(struct jsonipc_error*, int code, const char* fmt, ...);
+void jsonipc_error_set_from_errno(struct jsonipc_error*, const char* context);
+void jsonipc_error_cleanup(struct jsonipc_error*);
+
+struct jsonipc_request* jsonipc_request_parse_new(json_t* root,
+		struct jsonipc_error* err);
+struct jsonipc_request* jsonipc_request_new(const char* method, json_t* params);
+json_t* jsonipc_request_pack(struct jsonipc_request*, json_error_t* err);
+void jsonipc_request_destroy(struct jsonipc_request*);
+
+struct jsonipc_response* jsonipc_response_parse_new(json_t* root,
+		struct jsonipc_error* err);
+struct jsonipc_response* jsonipc_response_new(int code, json_t* data,
+		json_t* id);
+struct jsonipc_response* jsonipc_error_response_new(struct jsonipc_error* err,
+		json_t* id);
+void jsonipc_response_destroy(struct jsonipc_response*);
+json_t* jsonipc_response_pack(struct jsonipc_response*, json_error_t* err);
+
+json_t* jprintf(const char* fmt, ...);
+json_t* jvprintf(const char* fmt, va_list ap);

--- a/include/util.h
+++ b/include/util.h
@@ -17,3 +17,7 @@
 #pragma once
 
 #define UDIV_UP(a, b) (((a) + (b) - 1) / (b))
+
+extern const char* wayvnc_version;
+
+const char* default_ctl_socket_path();

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,7 @@ gbm = dependency('gbm', required: get_option('screencopy-dmabuf'))
 drm = dependency('libdrm')
 xkbcommon = dependency('xkbcommon', version: '>=1.0.0')
 wayland_client = dependency('wayland-client')
+jansson = dependency('jansson')
 
 neatvnc_version = '>=0.5.0'
 
@@ -89,6 +90,7 @@ sources = [
 	'src/buffer.c',
 	'src/pixels.c',
 	'src/transform-util.c',
+	'src/json-ipc.c',
 ]
 
 dependencies = [
@@ -102,6 +104,7 @@ dependencies = [
 	neatvnc,
 	xkbcommon,
 	client_protos,
+	jansson,
 ]
 
 config = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -172,17 +172,21 @@ if scdoc.found()
 	scdoc_prog = find_program(scdoc.get_pkgconfig_variable('scdoc'), native: true)
 	sh = find_program('sh', native: true)
 	mandir = get_option('mandir')
-	input = 'wayvnc.scd'
-	output = 'wayvnc.1'
+	manpages = {
+		'wayvnc.scd': 'wayvnc.1',
+		'wayvncctl.scd': 'wayvncctl.1',
+	}
 
-	custom_target(
-		output,
-		input: input,
-		output: output,
-		command: [
-			sh, '-c', '@0@ <@INPUT@ >@1@'.format(scdoc_prog.path(), output)
-		],
-		install: true,
-		install_dir: '@0@/man1'.format(mandir)
-	)
+	foreach input, output : manpages
+		custom_target(
+			output,
+			input: input,
+			output: output,
+			command: [
+				sh, '-c', '@0@ <@INPUT@ >@1@'.format(scdoc_prog.path(), output)
+			],
+			install: true,
+			install_dir: '@0@/man1'.format(mandir)
+		)
+	endforeach
 endif

--- a/meson.build
+++ b/meson.build
@@ -90,6 +90,7 @@ sources = [
 	'src/buffer.c',
 	'src/pixels.c',
 	'src/transform-util.c',
+	'src/util.c',
 	'src/json-ipc.c',
 	'src/ctl-server.c',
 ]

--- a/meson.build
+++ b/meson.build
@@ -91,6 +91,7 @@ sources = [
 	'src/pixels.c',
 	'src/transform-util.c',
 	'src/json-ipc.c',
+	'src/ctl-server.c',
 ]
 
 dependencies = [

--- a/meson.build
+++ b/meson.build
@@ -109,6 +109,18 @@ dependencies = [
 	jansson,
 ]
 
+ctlsources = [
+	'src/wayvncctl.c',
+	'src/util.c',
+	'src/json-ipc.c',
+	'src/ctl-client.c',
+	'src/strlcpy.c',
+]
+
+ctldependencies = [
+	jansson,
+]
+
 config = configuration_data()
 
 config.set('PREFIX', '"' + prefix + '"')
@@ -143,6 +155,14 @@ executable(
 	'wayvnc',
 	sources,
 	dependencies: dependencies,
+	include_directories: inc,
+	install: true,
+)
+
+executable(
+	'wayvncctl',
+	ctlsources,
+	dependencies: ctldependencies,
 	include_directories: inc,
 	install: true,
 )

--- a/src/ctl-client.c
+++ b/src/ctl-client.c
@@ -110,9 +110,14 @@ static struct jsonipc_request*	ctl_client_parse_args(struct ctl_client* self,
 	struct jsonipc_request* request = NULL;
 	const char* method = argv[0];
 	json_t* params = json_object();
+	bool show_usage = false;
 	for (int i = 1; i < argc; ++i) {
 		char* key = argv[i];
 		char* value = NULL;
+		if (strcmp(key, "--help") == 0 || strcmp(key, "-h") == 0) {
+			show_usage = true;
+			continue;
+		}
 		if (key[0] == '-' && key[1] == '-')
 			key += 2;
 		char* delim = strchr(key, '=');
@@ -126,6 +131,12 @@ static struct jsonipc_request*	ctl_client_parse_args(struct ctl_client* self,
 			goto failure;
 		}
 		json_object_set_new(params, key, json_string(value));
+	}
+	if (show_usage) {
+		// Special case for "foo --help"; convert into "help --command=foo"
+		json_object_clear(params);
+		json_object_set_new(params, "command", json_string(method));
+		method = "help";
 	}
 	request = jsonipc_request_new(method, params);
 

--- a/src/ctl-client.c
+++ b/src/ctl-client.c
@@ -296,6 +296,7 @@ static void print_help(json_t* data)
 						json_string_value(param_value));
 			}
 		}
+		printf("\nRun 'wayvncctl --help' for allowed Options\n");
 	}
 }
 

--- a/src/ctl-client.c
+++ b/src/ctl-client.c
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2022 Jim Ramsay
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <poll.h>
+#include <jansson.h>
+
+#include "json-ipc.h"
+#include "ctl-client.h"
+#include "ctl-server.h"
+#include "strlcpy.h"
+#include "util.h"
+
+#define WARN(fmt, ...) \
+	fprintf(stderr, "[WARNING] " fmt "\n", ##__VA_ARGS__)
+
+static bool do_debug = false;
+
+#define DEBUG(fmt, ...) \
+	if (do_debug) \
+		fprintf(stderr, "[%s:%d] " fmt "\n", __FILE__, __LINE__, ##__VA_ARGS__);
+
+#define FAILED_TO(action) \
+	WARN("Failed to " action ": %m");
+
+struct ctl_client {
+	void* userdata;
+
+	char read_buffer[512];
+	size_t read_len;
+
+	int fd;
+};
+
+void ctl_client_debug_log(bool enable)
+{
+	do_debug = enable;
+}
+
+struct ctl_client* ctl_client_new(const char* socket_path, void* userdata)
+{
+	if (!socket_path)
+		socket_path = default_ctl_socket_path();
+	struct ctl_client* new = calloc(1, sizeof(*new));
+	new->userdata = userdata;
+
+	struct sockaddr_un addr = {
+		.sun_family = AF_UNIX,
+	};
+
+	if (strlen(socket_path) >= sizeof(addr.sun_path)) {
+		errno = ENAMETOOLONG;
+		FAILED_TO("create unix socket");
+		goto socket_failure;
+	}
+	strcpy(addr.sun_path, socket_path);
+
+	new->fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (new->fd < 0) {
+		FAILED_TO("create unix socket");
+		goto socket_failure;
+	}
+
+	if (connect(new->fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+		FAILED_TO("connect to unix socket");
+		goto connect_failure;
+	}
+
+	return new;
+
+connect_failure:
+	close(new->fd);
+socket_failure:
+	free(new);
+	return NULL;
+}
+
+void ctl_client_destroy(struct ctl_client* self)
+{
+	close(self->fd);
+	free(self);
+}
+
+void* ctl_client_userdata(struct ctl_client* self)
+{
+	return self->userdata;
+}
+
+static struct jsonipc_request*	ctl_client_parse_args(struct ctl_client* self,
+		int argc, char* argv[])
+{
+	struct jsonipc_request* request = NULL;
+	const char* method = argv[0];
+	json_t* params = json_object();
+	for (int i = 1; i < argc; ++i) {
+		char* key = argv[i];
+		char* value = NULL;
+		if (key[0] == '-' && key[1] == '-')
+			key += 2;
+		char* delim = strchr(key, '=');
+		if (delim) {
+			*delim = '\0';
+			value = delim + 1;
+		} else if (++i < argc) {
+			value = argv[i];
+		} else {
+			WARN("Argument must be of the format --key=value or --key value");
+			goto failure;
+		}
+		json_object_set_new(params, key, json_string(value));
+	}
+	request = jsonipc_request_new(method, params);
+
+failure:
+	json_decref(params);
+	return request;
+}
+
+static ssize_t ctl_client_send_request(struct ctl_client* self,
+		struct jsonipc_request* request)
+{
+	json_error_t err;
+	json_t* packed = jsonipc_request_pack(request, &err);
+	if (!packed) {
+		WARN("Could not encode json: %s", err.text);
+		return -1;
+	}
+	char buffer[512];
+	int len = json_dumpb(packed, buffer, sizeof(buffer), JSON_COMPACT);
+	json_decref(packed);
+	DEBUG(">> %.*s", len, buffer);
+	return send(self->fd, buffer, len, MSG_NOSIGNAL);
+}
+
+static json_t* json_from_buffer(struct ctl_client* self)
+{
+	if (self->read_len == 0) {
+		DEBUG("Read buffer is empty");
+		errno = ENODATA;
+		return NULL;
+	}
+	json_error_t err;
+	json_t* root = json_loadb(self->read_buffer, self->read_len, 0, &err);
+	if (root) {
+		advance_read_buffer(&self->read_buffer, &self->read_len, err.position);
+	} else if (json_error_code(&err) == json_error_premature_end_of_input) {
+		DEBUG("Awaiting more data");
+		errno = ENODATA;
+	} else {
+		WARN("Json parsing failed: %s", err.text);
+		errno = EINVAL;
+	}
+	return root;
+}
+
+static json_t* read_one_object(struct ctl_client* self, int timeout_ms)
+{
+	json_t* root = json_from_buffer(self);
+	if (root)
+		return root;
+	if (errno != ENODATA)
+		return NULL;
+	struct pollfd pfd = {
+		.fd = self->fd,
+		.events = POLLIN,
+		.revents = 0
+	};
+	while (root == NULL) {
+		int n = poll(&pfd, 1, timeout_ms);
+		if (n == -1) {
+			if (errno == EINTR)
+				continue;
+			WARN("Error waiting for a response: %m");
+			break;
+		} else if (n == 0) {
+			WARN("Timeout waiting for a response");
+			break;
+		}
+		char* readptr = self->read_buffer + self->read_len;
+		size_t remainder = sizeof(self->read_buffer) - self->read_len;
+		n = recv(self->fd, readptr, remainder, 0);
+		if (n == -1) {
+			WARN("Read failed: %m");
+			break;
+		} else if (n == 0) {
+			WARN("Disconnected");
+			errno = ECONNRESET;
+			break;
+		}
+		DEBUG("Read %d bytes", n);
+		DEBUG("<< %.*s", n, readptr);
+		self->read_len += n;
+		root = json_from_buffer(self);
+		if (!root && errno != ENODATA)
+			break;
+	}
+	return root;
+}
+
+static struct jsonipc_response* ctl_client_wait_for_response(struct ctl_client* self)
+{
+	DEBUG("Waiting for a response");
+	json_t* root = read_one_object(self, 1000);
+	if (!root)
+		return NULL;
+	struct jsonipc_error jipc_err = JSONIPC_ERR_INIT;
+	struct jsonipc_response* response = jsonipc_response_parse_new(root,
+			&jipc_err);
+	if (!response) {
+		char* msg = json_dumps(jipc_err.data, JSON_EMBED);
+		WARN("Could not parse json: %s", msg);
+		free(msg);
+	}
+	json_decref(root);
+	jsonipc_error_cleanup(&jipc_err);
+	return response;
+}
+
+static int ctl_client_print_response(struct ctl_client* self,
+		struct jsonipc_response* response)
+{
+	DEBUG("Response code: %d", response->code);
+	if (response->data) {
+		char* data = json_dumps(response->data, JSON_INDENT(4));
+		printf("%s\n", data);
+		free(data);
+	}
+	return response->code;
+}
+
+int ctl_client_run_command(struct ctl_client* self,
+		int argc, char* argv[])
+{
+	int result = -1;
+	struct jsonipc_request*	request = ctl_client_parse_args(self, argc, argv);
+	if (!request)
+		goto parse_failure;
+
+	if (ctl_client_send_request(self, request) < 0)
+		goto send_failure;
+
+	struct jsonipc_response* response = ctl_client_wait_for_response(self);
+	if (!response)
+		goto receive_failure;
+
+	result = ctl_client_print_response(self, response);
+
+	jsonipc_response_destroy(response);
+receive_failure:
+send_failure:
+	jsonipc_request_destroy(request);
+parse_failure:
+	return result;
+}

--- a/src/ctl-server.c
+++ b/src/ctl-server.c
@@ -219,16 +219,7 @@ static ssize_t client_read(struct ctl_client* self, struct cmd_response** err)
 	return n;
 }
 
-static void client_advance_buffer(struct ctl_client* self, size_t len)
-{
-	size_t remainder = self->read_len - len;
-	if (remainder > 0)
-		memmove(self->read_buffer, self->read_buffer + len, remainder);
-	self->read_len = remainder;
-}
-
-static json_t* client_next_object(struct ctl_client* self,
-		struct cmd_response** ierr)
+static json_t* client_next_object(struct ctl_client* self, struct cmd_response** ierr)
 {
 	if (self->read_len == 0)
 		return NULL;
@@ -238,7 +229,7 @@ static json_t* client_next_object(struct ctl_client* self,
 			JSON_DISABLE_EOF_CHECK, &err);
 	if (root) {
 		nvnc_log(NVNC_LOG_DEBUG, "<< %.*s", err.position, self->read_buffer);
-		client_advance_buffer(self, err.position);
+		advance_read_buffer(&self->read_buffer, &self->read_len, err.position);
 	} else if (json_error_code(&err) == json_error_premature_end_of_input) {
 		nvnc_trace("Awaiting more data");
 	} else {

--- a/src/ctl-server.c
+++ b/src/ctl-server.c
@@ -1,0 +1,625 @@
+/*
+ * Copyright (c) 2022 Jim Ramsay
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <errno.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <netdb.h>
+#include <neatvnc.h>
+#include <aml.h>
+#include <jansson.h>
+
+#include "output.h"
+#include "ctl-server.h"
+#include "json-ipc.h"
+#include "util.h"
+#include "strlcpy.h"
+
+#define FAILED_TO(action) \
+	nvnc_log(NVNC_LOG_WARNING, "Failed to " action ": %m");
+
+enum cmd_type {
+	CMD_SET_OUTPUT,
+	CMD_UNKNOWN,
+};
+
+static char* cmd_name[] = {
+	[CMD_SET_OUTPUT] = "set-output",
+};
+
+struct cmd {
+	enum cmd_type type;
+};
+
+struct cmd_set_output {
+	struct cmd cmd;
+	char target[64];
+	enum output_cycle_direction cycle;
+};
+
+struct cmd_response {
+	int code;
+	json_t* data;
+};
+
+struct ctl_client {
+	int fd;
+	struct wl_list link;
+	struct ctl* server;
+	struct aml_handler* handler;
+	char read_buffer[512];
+	size_t read_len;
+	json_t* response_queue;
+	char* write_buffer;
+	char* write_ptr;
+	size_t write_len;
+	bool drop_after_next_send;
+};
+
+struct ctl {
+	char socket_path[255];
+	struct ctl_server_actions actions;
+	int fd;
+	struct aml_handler* handler;
+	struct wl_list clients;
+};
+
+static struct cmd_response* cmd_response_new(int code, json_t* data)
+{
+	struct cmd_response* new = calloc(1, sizeof(struct cmd_response));
+	new->code = code;
+	new->data = data;
+	return new;
+}
+
+static void cmd_response_destroy(struct cmd_response* self)
+{
+	json_decref(self->data);
+	free(self);
+}
+
+static enum cmd_type parse_command_name(const char* name)
+{
+	for (int i = 0; i < CMD_UNKNOWN; ++i) {
+		if (strcmp(name, cmd_name[i]) == 0) {
+			return i;
+		}
+	}
+	return CMD_UNKNOWN;
+}
+
+static struct cmd_set_output* cmd_set_output_new(json_t* args,
+		struct jsonipc_error* err)
+{
+	const char* target = NULL;
+	const char* cycle = NULL;
+	if (json_unpack(args, "{s?s,s?s}",
+			"switch-to", &target,
+			"cycle", &cycle) == -1) {
+		jsonipc_error_printf(err, EINVAL,
+				"expecting \"switch-to\" or \"cycle\"");
+		return NULL;
+	}
+	if ((!target && !cycle) || (target && cycle)) {
+		jsonipc_error_printf(err, EINVAL,
+				"expecting exactly one of \"switch-to\" or \"cycle\"");
+		return NULL;
+	}
+	struct cmd_set_output* cmd = calloc(1, sizeof(*cmd));
+	cmd->cmd.type = CMD_SET_OUTPUT;
+	if (target) {
+		strlcpy(cmd->target, target, sizeof(cmd->target));
+	} else if (cycle) {
+		if (strncmp(cycle, "prev", 4) == 0)
+			cmd->cycle = OUTPUT_CYCLE_REVERSE;
+		else if (strcmp(cycle, "next") == 0)
+			cmd->cycle = OUTPUT_CYCLE_FORWARD;
+		else {
+			jsonipc_error_printf(err, EINVAL,
+				"cycle must either be \"next\" or \"prev\"");
+			free(cmd);
+			return NULL;
+		}
+	}
+	return cmd;
+}
+
+static struct cmd* parse_command(struct jsonipc_request* ipc,
+		struct jsonipc_error* err)
+{
+	nvnc_trace("Parsing command %s", ipc->method);
+	enum cmd_type cmd_type = parse_command_name(ipc->method);
+	struct cmd* cmd = NULL;
+	switch (cmd_type) {
+	case CMD_SET_OUTPUT:
+		cmd = (struct cmd*)cmd_set_output_new(ipc->params, err);
+		break;
+	default: {
+		json_t* allowed = json_array();
+		for (int i = 0; i < CMD_UNKNOWN; ++i)
+			json_array_append_new(allowed, json_string(cmd_name[i]));
+		jsonipc_error_set_new(err, ENOENT,
+				json_pack("{s:o, s:o}",
+					"error",
+					jprintf("Unknown command \"%s\"",
+						ipc->method),
+					"commands", allowed));
+		 }
+	}
+	return cmd;
+}
+
+static void client_destroy(struct ctl_client* self)
+{
+	nvnc_trace("Destroying client %p", self);
+	aml_stop(aml_get_default(), self->handler);
+	aml_unref(self->handler);
+	close(self->fd);
+	json_array_clear(self->response_queue);
+	json_decref(self->response_queue);
+	wl_list_remove(&self->link);
+	free(self);
+}
+static void set_internal_error(struct cmd_response** err, int code,
+		const char* fmt, ...)
+{
+	char msg[256];
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(msg, sizeof(msg), fmt, ap);
+	va_end(ap);
+	nvnc_log(NVNC_LOG_WARNING, msg);
+	*err = cmd_response_new(code, json_pack("{s:s}", "error", msg));
+}
+
+// Return values:
+// >0: Number of bytes read
+// 0: No bytes read (EAGAIN)
+// -1: Fatal error.  Check 'err' for details, or if 'err' is null, terminate the connection.
+static ssize_t client_read(struct ctl_client* self, struct cmd_response** err)
+{
+	size_t bufferspace = sizeof(self->read_buffer) - self->read_len;
+	if (bufferspace == 0) {
+		set_internal_error(err, EIO, "Buffer overflow");
+		return -1;
+	}
+	ssize_t n = recv(self->fd, self->read_buffer + self->read_len, bufferspace,
+			MSG_DONTWAIT);
+	if (n == -1) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			nvnc_trace("recv: EAGAIN");
+			return 0;
+		}
+		set_internal_error(err, EIO, "Read failed: %m");
+		return -1;
+	} else if (n == 0) {
+		nvnc_log(NVNC_LOG_INFO, "Control socket client disconnected: %p", self);
+		errno = ENOTCONN;
+		return -1;
+	}
+	self->read_len += n;
+	nvnc_trace("Read %d bytes, total is now %d", n, self->read_len);
+	return n;
+}
+
+static void client_advance_buffer(struct ctl_client* self, size_t len)
+{
+	size_t remainder = self->read_len - len;
+	if (remainder > 0)
+		memmove(self->read_buffer, self->read_buffer + len, remainder);
+	self->read_len = remainder;
+}
+
+static json_t* client_next_object(struct ctl_client* self,
+		struct cmd_response** ierr)
+{
+	if (self->read_len == 0)
+		return NULL;
+
+	json_error_t err;
+	json_t* root = json_loadb(self->read_buffer, self->read_len,
+			JSON_DISABLE_EOF_CHECK, &err);
+	if (root) {
+		nvnc_log(NVNC_LOG_DEBUG, "<< %.*s", err.position, self->read_buffer);
+		client_advance_buffer(self, err.position);
+	} else if (json_error_code(&err) == json_error_premature_end_of_input) {
+		nvnc_trace("Awaiting more data");
+	} else {
+		set_internal_error(ierr, EINVAL, err.text);
+	}
+	return root;
+}
+
+static struct cmd_response* ctl_server_dispatch_cmd(struct ctl* self, struct cmd* cmd)
+{
+	assert(cmd->type != CMD_UNKNOWN);
+	const char* name = cmd_name[cmd->type];
+	nvnc_log(NVNC_LOG_INFO, "Dispatching control client command '%s'", name);
+	struct cmd_response* response = NULL;
+	switch (cmd->type) {
+	case CMD_SET_OUTPUT: {
+		struct cmd_set_output* c = (struct cmd_set_output*)cmd;
+		if (c->target[0] != '\0')
+			response = self->actions.on_output_switch(self, c->target);
+		else
+			response = self->actions.on_output_cycle(self, c->cycle);
+	     }
+	case CMD_UNKNOWN:
+		break;
+	}
+	return response;
+}
+
+static void client_set_aml_event_mask(struct ctl_client* self)
+{
+	int mask = AML_EVENT_READ;
+	if (json_array_size(self->response_queue) > 0 ||
+			self->write_len)
+		mask |= AML_EVENT_WRITE;
+	aml_set_event_mask(self->handler, mask);
+}
+
+static int client_enqueue_jsonipc(struct ctl_client* self,
+		struct jsonipc_response* resp)
+{
+	int result = 0;
+	json_error_t err;
+	json_t* packed_response = jsonipc_response_pack(resp, &err);
+	if (!packed_response) {
+		nvnc_log(NVNC_LOG_WARNING, "Pack failed: %s", err.text);
+		result = -1;
+		goto failure;
+	}
+	result = json_array_append_new(self->response_queue, packed_response);
+	if (result != 0) {
+		nvnc_log(NVNC_LOG_WARNING, "Append failed");
+		goto failure;
+	}
+	client_set_aml_event_mask(self);
+failure:
+	jsonipc_response_destroy(resp);
+	return result;
+}
+
+static int client_enqueue_error(struct ctl_client* self,
+		struct jsonipc_error* err, json_t* id)
+{
+	struct jsonipc_response* resp = jsonipc_error_response_new(err, id);
+	return client_enqueue_jsonipc(self, resp);
+}
+
+static int client_enqueue_response(struct ctl_client* self,
+		struct cmd_response* response, json_t* id)
+{
+	nvnc_log(NVNC_LOG_INFO, "Enqueueing response: %s (%d)",
+			response->code == 0 ? "OK" : "FAILED", response->code);
+	char* str = NULL;
+	if (response->data)
+		str = json_dumps(response->data, 0);
+	nvnc_log(NVNC_LOG_DEBUG, "Response data: %s", str);
+	if(str)
+		free(str);
+	struct jsonipc_response* resp =
+		jsonipc_response_new(response->code, response->data, id);
+	cmd_response_destroy(response);
+	return client_enqueue_jsonipc(self, resp);
+}
+
+static int client_enqueue_internal_error(struct ctl_client* self,
+		struct cmd_response* err)
+{
+	int result = client_enqueue_response(self, err, NULL);
+	if (result != 0)
+		client_destroy(self);
+	self->drop_after_next_send = true;
+	return result;
+}
+
+static void send_ready(struct ctl_client* client)
+{
+	if (client->write_buffer) {
+		nvnc_trace("Continuing partial write (%d left)", client->write_len);
+	} else if (json_array_size(client->response_queue) > 0){
+		nvnc_trace("Sending new queued message");
+		json_t* item = json_array_get(client->response_queue, 0);
+		client->write_len = json_dumpb(item, NULL, 0, JSON_COMPACT);
+		client->write_buffer = calloc(1, client->write_len);
+		client->write_ptr = client->write_buffer;
+		json_dumpb(item, client->write_buffer, client->write_len,
+				JSON_COMPACT);
+		nvnc_log(NVNC_LOG_DEBUG, ">> %.*s", client->write_len, client->write_buffer);
+		json_array_remove(client->response_queue, 0);
+	} else {
+		nvnc_trace("Nothing to send");
+	}
+	if (!client->write_ptr)
+		goto no_data;
+	ssize_t n = send(client->fd, client->write_ptr, client->write_len,
+			MSG_NOSIGNAL|MSG_DONTWAIT);
+	if (n == -1) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			nvnc_trace("send: EAGAIN");
+			goto send_eagain;
+		}
+		nvnc_log(NVNC_LOG_ERROR, "Could not send response: %m");
+		client_destroy(client);
+		return;
+	}
+	nvnc_trace("sent %d/%d bytes", n, client->write_len);
+	client->write_ptr += n;
+	client->write_len -= n;
+send_eagain:
+	if (client->write_len == 0) {
+		nvnc_trace("Write buffer empty!");
+		free(client->write_buffer);
+		client->write_buffer = NULL;
+		client->write_ptr = NULL;
+		if (client->drop_after_next_send) {
+			nvnc_log(NVNC_LOG_WARNING, "Intentional disconnect");
+			client_destroy(client);
+			return;
+		}
+	} else {
+		nvnc_trace("Write buffer has %d remaining", client->write_len);
+	}
+no_data:
+	client_set_aml_event_mask(client);
+}
+
+static void recv_ready(struct ctl_client* client)
+{
+	struct ctl* server = client->server;
+	struct cmd_response* details = NULL;
+	switch (client_read(client, &details)) {
+	case 0: // Needs more data
+		return;
+	case -1: // Fatal error
+		if (details)
+			client_enqueue_internal_error(client, details);
+		else
+			client_destroy(client);
+		return;
+	default: // Read some data; check it
+		break;
+	}
+
+	json_t* root;
+	while (true) {
+		root = client_next_object(client, &details);
+		if (root == NULL)
+			break;
+
+		struct jsonipc_error jipc_err = JSONIPC_ERR_INIT;
+
+		struct jsonipc_request* request =
+			jsonipc_request_parse_new(root, &jipc_err);
+		if (!request) {
+			client_enqueue_error(client, &jipc_err,
+					NULL);
+			goto request_parse_failed;
+		}
+
+		struct cmd* cmd = parse_command(request, &jipc_err);
+		if (!cmd) {
+			client_enqueue_error(client, &jipc_err,
+					request->id);
+			goto cmdparse_failed;
+		}
+
+		// TODO: Enqueue the command (and request ID) to be
+		// handled by the main loop instead of doing the
+		// dispatch here
+		struct cmd_response* response =
+			ctl_server_dispatch_cmd(server, cmd);
+		if (!response)
+			goto no_response;
+		client_enqueue_response(client, response, request->id);
+no_response:
+		free(cmd);
+cmdparse_failed:
+		jsonipc_request_destroy(request);
+request_parse_failed:
+		jsonipc_error_cleanup(&jipc_err);
+		json_decref(root);
+	}
+	if (details)
+		client_enqueue_internal_error(client, details);
+}
+
+static void on_ready(void* obj)
+{
+	struct ctl_client* client = aml_get_userdata(obj);
+	uint32_t events = aml_get_revents(obj);
+	nvnc_trace("Client %p ready: 0x%x", client, events);
+
+	if (events & AML_EVENT_WRITE)
+		send_ready(client);
+	else if (events & AML_EVENT_READ)
+		recv_ready(client);
+}
+
+static void on_connection(void* obj)
+{
+	nvnc_log(NVNC_LOG_DEBUG, "New connection");
+	struct ctl* server = aml_get_userdata(obj);
+
+	struct ctl_client* client = calloc(1, sizeof(*client));
+	if (!client) {
+		FAILED_TO("allocate a client object");
+		return;
+	}
+
+	client->server = server;
+	client->response_queue = json_array();
+
+	client->fd = accept(server->fd, NULL, 0);
+	if (client->fd < 0) {
+		FAILED_TO("accept a connection");
+		goto accept_failure;
+	}
+
+	client->handler = aml_handler_new(client->fd, on_ready, client, NULL);
+	if (!client->handler) {
+		FAILED_TO("create a loop handler");
+		goto handle_failure;
+	}
+
+	if (aml_start(aml_get_default(), client->handler) < 0) {
+		FAILED_TO("register for client events");
+		goto poll_start_failure;
+	}
+
+	wl_list_insert(&server->clients, &client->link);
+	nvnc_log(NVNC_LOG_INFO, "New control socket client connected: %p", client);
+	return;
+
+poll_start_failure:
+	aml_unref(client->handler);
+handle_failure:
+	close(client->fd);
+accept_failure:
+	json_decref(client->response_queue);
+	free(client);
+}
+
+const char* default_ctl_socket_path()
+{
+	static char buffer[128];
+	char* xdg_runtime = getenv("XDG_RUNTIME_DIR");
+	if (xdg_runtime)
+		snprintf(buffer, sizeof(buffer),
+				"%s/wayvncctl", xdg_runtime);
+	else
+		snprintf(buffer, sizeof(buffer),
+				"/tmp/wayvncctl-%d", getuid());
+	return buffer;
+}
+
+int ctl_server_init(struct ctl* self, const char* socket_path)
+{
+	if (!socket_path) {
+		socket_path = default_ctl_socket_path();
+		if (!getenv("XDG_RUNTIME_DIR"))
+			nvnc_log(NVNC_LOG_WARNING, "$XDG_RUNTIME_DIR is not set. Falling back to control socket \"%s\"", socket_path);
+	}
+	strlcpy(self->socket_path, socket_path, sizeof(self->socket_path));
+	nvnc_log(NVNC_LOG_DEBUG, "Initializing wayvncctl socket: %s", self->socket_path);
+
+	wl_list_init(&self->clients);
+
+	struct sockaddr_un addr = {
+		.sun_family = AF_UNIX,
+	};
+
+	if (strlen(self->socket_path) >= sizeof(addr.sun_path)) {
+		errno = ENAMETOOLONG;
+		FAILED_TO("create unix socket");
+		goto socket_failure;
+	}
+	strcpy(addr.sun_path, self->socket_path);
+
+	self->fd = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (self->fd < 0) {
+		FAILED_TO("create unix socket");
+		goto socket_failure;
+	}
+
+	if (bind(self->fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+		FAILED_TO("bind unix socket");
+		goto bind_failure;
+	}
+
+	if (listen(self->fd, 16) < 0) {
+		FAILED_TO("listen to unix socket");
+		goto listen_failure;
+	}
+
+	self->handler = aml_handler_new(self->fd, on_connection, self, NULL);
+	if (!self->handler) {
+		FAILED_TO("create a main loop handler");
+		goto handle_failure;
+	}
+
+	if (aml_start(aml_get_default(), self->handler) < 0) {
+		FAILED_TO("Register for server events");
+		goto poll_start_failure;
+	}
+	return 0;
+
+poll_start_failure:
+	aml_unref(self->handler);
+handle_failure:
+listen_failure:
+	close(self->fd);
+	unlink(self->socket_path);
+bind_failure:
+socket_failure:
+	return -1;
+}
+
+static void ctl_server_stop(struct ctl* self)
+{
+	aml_stop(aml_get_default(), self->handler);
+	aml_unref(self->handler);
+	struct ctl_client* client;
+	struct ctl_client* tmp;
+	wl_list_for_each_safe(client, tmp, &self->clients, link)
+		client_destroy(client);
+	close(self->fd);
+	unlink(self->socket_path);
+}
+
+struct ctl* ctl_server_new(const char* socket_path,
+		const struct ctl_server_actions* actions)
+{
+	struct ctl* ctl = calloc(1, sizeof(*ctl));
+	memcpy(&ctl->actions, actions, sizeof(*actions));
+	if (ctl_server_init(ctl, socket_path) != 0) {
+		free(ctl);
+		return NULL;
+	}
+	return ctl;
+}
+
+void ctl_server_destroy(struct ctl* self)
+{
+	ctl_server_stop(self);
+	free(self);
+}
+
+void* ctl_server_userdata(struct ctl* self)
+{
+	return self->actions.userdata;
+}
+
+struct cmd_response* cmd_ok()
+{
+	return cmd_response_new(0, NULL);
+}
+
+struct cmd_response* cmd_failed(const char* fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	struct cmd_response* resp = cmd_response_new(1, json_pack("{s:o}",
+				"error", jvprintf(fmt, ap)));
+	va_end(ap);
+	return resp;
+}

--- a/src/ctl-server.c
+++ b/src/ctl-server.c
@@ -339,7 +339,7 @@ static struct cmd_response* generate_version_object()
 	return response;
 }
 
-static 	struct cmd_response* ctl_server_dispatch_cmd(struct ctl* self, struct cmd* cmd)
+static struct cmd_response* ctl_server_dispatch_cmd(struct ctl* self, struct cmd* cmd)
 {
 	assert(cmd->type != CMD_UNKNOWN);
 	const struct cmd_info* info = &cmd_list[cmd->type];

--- a/src/ctl-server.c
+++ b/src/ctl-server.c
@@ -499,19 +499,6 @@ accept_failure:
 	free(client);
 }
 
-const char* default_ctl_socket_path()
-{
-	static char buffer[128];
-	char* xdg_runtime = getenv("XDG_RUNTIME_DIR");
-	if (xdg_runtime)
-		snprintf(buffer, sizeof(buffer),
-				"%s/wayvncctl", xdg_runtime);
-	else
-		snprintf(buffer, sizeof(buffer),
-				"/tmp/wayvncctl-%d", getuid());
-	return buffer;
-}
-
 int ctl_server_init(struct ctl* self, const char* socket_path)
 {
 	if (!socket_path) {

--- a/src/json-ipc.c
+++ b/src/json-ipc.c
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2022 Jim Ramsay
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <string.h>
+#include <stdbool.h>
+#include <errno.h>
+#include "json-ipc.h"
+
+static const char* jsonipc_id_key = "id";
+static const char* jsonipc_method_key = "method";
+static const char* jsonipc_params_key = "params";
+static const char* jsonipc_code_key = "code";
+static const char* jsonipc_data_key = "data";
+
+void jsonipc_error_set_new(struct jsonipc_error* err, int code, json_t* data)
+{
+	if (!err)
+		return;
+	err->code = code;
+	err->data = data;
+}
+
+void jsonipc_error_printf(struct jsonipc_error* err, int code, const char* fmt, ...)
+{
+	va_list ap;
+	va_start(ap, fmt);
+	jsonipc_error_set_new(err, code, json_pack("{s:o}", "error",
+				jvprintf(fmt, ap)));
+	va_end(ap);
+}
+
+void jsonipc_error_set_from_errno(struct jsonipc_error* err,
+		const char* context)
+{
+	jsonipc_error_printf(err, errno, "%s: %m", context);
+}
+
+void jsonipc_error_cleanup(struct jsonipc_error* err)
+{
+	if (!err)
+		return;
+	json_decref(err->data);
+}
+
+inline static bool is_valid_id(json_t* id)
+{
+	return id == NULL ||
+		json_is_string(id) || json_is_number(id);
+}
+
+struct jsonipc_request* jsonipc_request_parse_new(json_t* root,
+		struct jsonipc_error* err)
+{
+	struct jsonipc_request* ipc = calloc(1, sizeof(*ipc));
+	ipc->json = root;
+	json_incref(ipc->json);
+	json_error_t unpack_error;
+	if (json_unpack_ex(root, &unpack_error, 0, "{s:s, s?O, s?O}",
+				jsonipc_method_key, &ipc->method,
+				jsonipc_params_key, &ipc->params,
+				jsonipc_id_key, &ipc->id) == -1) {
+		jsonipc_error_printf(err, EINVAL, unpack_error.text);
+		goto failure;
+	}
+	if (!is_valid_id(ipc->id)) {
+		char* id = json_dumps(ipc->id, JSON_EMBED | JSON_ENCODE_ANY);
+		jsonipc_error_printf(err, EINVAL,
+				"Invalid ID \"%s\"", id);
+		free(id);
+		goto failure;
+	}
+	return ipc;
+
+failure:
+	jsonipc_request_destroy(ipc);
+	return NULL;
+}
+
+static int request_id = 1;
+struct jsonipc_request* jsonipc_request_new(const char* method, json_t* params)
+{
+	struct jsonipc_request* ipc = calloc(1, sizeof(*ipc));
+	ipc->method = method;
+	ipc->params = params;
+	json_incref(ipc->params);
+	ipc->id = json_integer(request_id++);
+	return ipc;
+}
+
+json_t* jsonipc_request_pack(struct jsonipc_request* self, json_error_t* err)
+{
+	return json_pack_ex(err, 0, "{s:s, s:O*, s:O*}",
+			jsonipc_method_key, self->method,
+			jsonipc_params_key, self->params,
+			jsonipc_id_key, self->id);
+}
+
+void jsonipc_request_destroy(struct jsonipc_request* self)
+{
+	json_decref(self->params);
+	json_decref(self->id);
+	json_decref(self->json);
+	free(self);
+}
+
+struct jsonipc_response* jsonipc_response_parse_new(json_t* root,
+		struct jsonipc_error* err)
+{
+	struct jsonipc_response* ipc = calloc(1, sizeof(*ipc));
+	ipc->json = root;
+	json_incref(ipc->json);
+	json_error_t unpack_error;
+	if (json_unpack_ex(root, &unpack_error, 0, "{s:i, s?O, s?O}",
+				jsonipc_code_key, &ipc->code,
+				jsonipc_data_key, &ipc->data,
+				jsonipc_id_key, &ipc->id) == -1) {
+		jsonipc_error_printf(err, EINVAL, unpack_error.text);
+		goto failure;
+	}
+	if (!is_valid_id(ipc->id)) {
+		char* id = json_dumps(ipc->id, JSON_EMBED | JSON_ENCODE_ANY);
+		jsonipc_error_printf(err, EINVAL,
+				"Invalid ID \"%s\"", id);
+		free(id);
+		goto failure;
+	}
+	return ipc;
+
+failure:
+	jsonipc_response_destroy(ipc);
+	return NULL;
+}
+
+struct jsonipc_response* jsonipc_response_new(int code,
+		json_t* data, json_t* id)
+{
+	struct jsonipc_response* rsp = calloc(1, sizeof(*rsp));
+	rsp->code = code;
+	json_incref(id);
+	rsp->id = id;
+	json_incref(data);
+	rsp->data = data;
+	return rsp;
+}
+
+struct jsonipc_response* jsonipc_error_response_new(
+		struct jsonipc_error* err,
+		json_t* id)
+{
+	return jsonipc_response_new(err->code, err->data, id);
+}
+
+void jsonipc_response_destroy(struct jsonipc_response* self)
+{
+	json_decref(self->data);
+	json_decref(self->json);
+	json_decref(self->id);
+	free(self);
+}
+
+json_t* jsonipc_response_pack(struct jsonipc_response* self, json_error_t* err)
+{
+	return json_pack_ex(err, 0, "{s:i, s:O*, s:O*}",
+			jsonipc_code_key, self->code,
+			jsonipc_id_key, self->id,
+			jsonipc_data_key, self->data);
+}
+
+json_t* jprintf(const char* fmt, ...)
+{
+	va_list args;
+	va_start(args, fmt);
+	json_t* result = jvprintf(fmt, args);
+	va_end(args);
+	return result;
+}
+
+json_t* jvprintf(const char* fmt, va_list ap)
+{
+	char buffer[128];
+	int len = vsnprintf(buffer, sizeof(buffer), fmt, ap);
+	return json_stringn(buffer, len);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,7 @@
 #include "transform-util.h"
 #include "usdt.h"
 #include "ctl-server.h"
+#include "util.h"
 
 #ifdef ENABLE_PAM
 #include "pam_auth.h"
@@ -113,14 +114,6 @@ static void on_client_new(struct nvnc_client* client);
 void switch_to_output(struct wayvnc*, struct output*);
 void switch_to_next_output(struct wayvnc*);
 void switch_to_prev_output(struct wayvnc*);
-
-#if defined(GIT_VERSION)
-static const char wayvnc_version[] = GIT_VERSION;
-#elif defined(PROJECT_VERSION)
-static const char wayvnc_version[] = PROJECT_VERSION;
-#else
-static const char wayvnc_version[] = "UNKNOWN";
-#endif
 
 struct wl_shm* wl_shm = NULL;
 struct zwp_linux_dmabuf_v1* zwp_linux_dmabuf = NULL;

--- a/src/util.c
+++ b/src/util.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2019 - 2022 Andri Yngvason
  * Copyright (c) 2022 Jim Ramsay
  *
  * Permission to use, copy, modify, and/or distribute this software for any
@@ -14,26 +15,31 @@
  * PERFORMANCE OF THIS SOFTWARE.
  */
 
-#pragma once
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
 
-#include "output.h"
-#include <wayland-client.h>
+#include "util.h"
 
-struct ctl;
-struct cmd_response;
+const char* wayvnc_version =
+#if defined(GIT_VERSION)
+		GIT_VERSION;
+#elif defined(PROJECT_VERSION)
+		PROJECT_VERSION;
+#else
+		"UNKNOWN";
+#endif
 
-struct ctl_server_actions {
-	void* userdata;
-	struct cmd_response* (*on_output_cycle)(struct ctl*,
-			enum output_cycle_direction direction);
-	struct cmd_response* (*on_output_switch)(struct ctl*,
-			const char* output_name);
-};
-
-struct ctl* ctl_server_new(const char* socket_path,
-		const struct ctl_server_actions* actions);
-void ctl_server_destroy(struct ctl*);
-void* ctl_server_userdata(struct ctl*);
-
-struct cmd_response* cmd_ok(void);
-struct cmd_response* cmd_failed(const char* fmt, ...);
+const char* default_ctl_socket_path()
+{
+	static char buffer[128];
+	char* xdg_runtime = getenv("XDG_RUNTIME_DIR");
+	if (xdg_runtime)
+		snprintf(buffer, sizeof(buffer),
+				"%s/wayvncctl", xdg_runtime);
+	else
+		snprintf(buffer, sizeof(buffer),
+				"/tmp/wayvncctl-%d", getuid());
+	return buffer;
+}

--- a/src/util.c
+++ b/src/util.c
@@ -43,3 +43,13 @@ const char* default_ctl_socket_path()
 				"/tmp/wayvncctl-%d", getuid());
 	return buffer;
 }
+
+void advance_read_buffer(char (*buffer)[], size_t* current_len, size_t advance_by)
+{
+	ssize_t remainder = *current_len - advance_by;
+	if (remainder < 0)
+		remainder = 0;
+	else if (remainder > 0)
+		memmove(*buffer, *buffer + advance_by, remainder);
+	*current_len = remainder;
+}

--- a/src/wayvncctl.c
+++ b/src/wayvncctl.c
@@ -51,6 +51,7 @@ static int wayvncctl_usage(FILE* stream, int rc)
 "Try the \"help\" command for a list of available commands.\n"
 "\n"
 "    -S,--socket=<path>                        Wayvnc control socket path.\n"
+"    -j,--json                                 Output json on stdout.\n"
 "                                              Default: $XDG_RUNTIME_DIR/wayvncctl\n"
 "    -V,--version                              Show version info.\n"
 "    -v,--verbose                              Be more verbose.\n"
@@ -72,13 +73,16 @@ int main(int argc, char* argv[])
 {
 	struct wayvncctl self = { 0 };
 
-	static const char* shortopts = "+S:hVv";
+	static const char* shortopts = "+S:hVvj";
 
 	bool verbose = false;
 	const char* socket_path = NULL;
 
+	unsigned flags = 0;
+
 	static const struct option longopts[] = {
 		{ "socket", required_argument, NULL, 'S' },
+		{ "json", no_argument, NULL, 'j' },
 		{ "help", no_argument, NULL, 'h' },
 		{ "version", no_argument, NULL, 'V' },
 		{ "verbose", no_argument, NULL, 'v' },
@@ -93,6 +97,9 @@ int main(int argc, char* argv[])
 		switch (c) {
 		case 'S':
 			socket_path = optarg;
+			break;
+		case 'j':
+			flags |= PRINT_JSON;
 			break;
 		case 'v':
 			verbose = true;
@@ -113,7 +120,7 @@ int main(int argc, char* argv[])
 	if (!self.ctl)
 		goto ctl_client_failure;
 
-	int result = ctl_client_run_command(self.ctl, argc, argv);
+	int result = ctl_client_run_command(self.ctl, argc, argv, flags);
 
 	ctl_client_destroy(self.ctl);
 

--- a/src/wayvncctl.c
+++ b/src/wayvncctl.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022 Jim Ramsay
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <assert.h>
+#include <inttypes.h>
+#include <errno.h>
+#include <signal.h>
+#include <sys/param.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "util.h"
+#include "ctl-client.h"
+
+#define MAYBE_UNUSED __attribute__((unused))
+
+struct wayvncctl {
+	bool do_exit;
+
+	struct ctl_client* ctl;
+};
+
+static int wayvncctl_usage(FILE* stream, int rc)
+{
+	static const char* usage =
+"Usage: wayvncctl [options] [command [--param1=value1 ...]]\n"
+"\n"
+"Connects to and interacts with a running wauvnc instance."
+"\n"
+"Try the \"help\" command for a list of available commands.\n"
+"\n"
+"    -S,--socket=<path>                        Wayvnc control socket path.\n"
+"                                              Default: $XDG_RUNTIME_DIR/wayvncctl\n"
+"    -V,--version                              Show version info.\n"
+"    -v,--verbose                              Be more verbose.\n"
+"    -h,--help                                 Get help (this text).\n"
+"\n";
+
+	fprintf(stream, "%s", usage);
+
+	return rc;
+}
+
+static int show_version(void)
+{
+	printf("wayvnc: %s\n", wayvnc_version);
+	return 0;
+}
+
+int main(int argc, char* argv[])
+{
+	struct wayvncctl self = { 0 };
+
+	static const char* shortopts = "+S:hVv";
+
+	bool verbose = false;
+	const char* socket_path = NULL;
+
+	static const struct option longopts[] = {
+		{ "socket", required_argument, NULL, 'S' },
+		{ "help", no_argument, NULL, 'h' },
+		{ "version", no_argument, NULL, 'V' },
+		{ "verbose", no_argument, NULL, 'v' },
+		{ NULL, 0, NULL, 0 }
+	};
+
+	while (1) {
+		int c = getopt_long(argc, argv, shortopts, longopts, NULL);
+		if (c < 0)
+			break;
+
+		switch (c) {
+		case 'S':
+			socket_path = optarg;
+			break;
+		case 'v':
+			verbose = true;
+			break;
+		case 'V':
+			return show_version();
+		case 'h':
+			return wayvncctl_usage(stdout, 0);
+		default:
+			return wayvncctl_usage(stderr, 1);
+		}
+	}
+	argc -= optind;
+	argv = &argv[optind];
+
+	ctl_client_debug_log(verbose);
+	self.ctl = ctl_client_new(socket_path, &self);
+	if (!self.ctl)
+		goto ctl_client_failure;
+
+	int result = ctl_client_run_command(self.ctl, argc, argv);
+
+	ctl_client_destroy(self.ctl);
+
+	return result;
+
+ctl_client_failure:
+	return 1;
+}

--- a/src/wayvncctl.c
+++ b/src/wayvncctl.c
@@ -46,16 +46,17 @@ static int wayvncctl_usage(FILE* stream, int rc)
 	static const char* usage =
 "Usage: wayvncctl [options] [command [--param1=value1 ...]]\n"
 "\n"
-"Connects to and interacts with a running wauvnc instance."
+"Connects to and interacts with a running wayvnc instance."
 "\n"
-"Try the \"help\" command for a list of available commands.\n"
+"Try 'wayvncctl help' for a list of available commands.\n"
 "\n"
-"    -S,--socket=<path>                        Wayvnc control socket path.\n"
-"    -j,--json                                 Output json on stdout.\n"
-"                                              Default: $XDG_RUNTIME_DIR/wayvncctl\n"
-"    -V,--version                              Show version info.\n"
-"    -v,--verbose                              Be more verbose.\n"
-"    -h,--help                                 Get help (this text).\n"
+"Options:\n"
+"    -S,--socket=<path>                   Wayvnc control socket path.\n"
+"    -j,--json                            Output json on stdout.\n"
+"                                         Default: $XDG_RUNTIME_DIR/wayvncctl\n"
+"    -V,--version                         Show version info.\n"
+"    -v,--verbose                         Be more verbose.\n"
+"    -h,--help                            Get help (this text).\n"
 "\n";
 
 	fprintf(stream, "%s", usage);

--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -25,6 +25,10 @@ wayvnc - A VNC server for wlroots based Wayland compositors.
 *-s, --seat=<name>*
 	Select seat by name.
 
+*-S, --socket=<path>*
+	Set wayvnc control socket path. Default: $XDG_RUNTIME_DIR/wayvncctl
+	or /tmp/wayvncctl-$UID
+
 *-r, --render-cursor*
 	Enable overlay cursor rendering.
 
@@ -148,6 +152,101 @@ private_key_file=/path/to/key.pem
 certificate_file=/path/to/cert.pem
 ```
 
+# WAYVNCCTL CONTROL SOCKET
+
+To facilitate runtime interaction and control, wayvnc opens a unix domain socket
+at *$XDG_RUNTIME_DIR*/wayvncctl (or a fallback of /tmp/wayvncctl-*$UID*). A
+client can connect and exchange json-formatted IPC messages to query and control
+the running wayvnc instance.
+
+## IPC COMMANDS
+
+_HELP_
+
+The *help* command, when issued without any parameters, lists the names of all
+available commands.
+
+If an optional *command* parameter refers to one of those commands by name, the
+response data will be a detailed description of that command and its parameters.
+
+_VERSION_
+
+The *version* command queries the running wayvnc instance for its version
+information. Much like the _-V_ option, the response data will contain the
+version numbers of wayvnc, as well as the versions of the neatvnc and aml
+components.
+
+_SET-OUTPUT_
+
+For multi-output wayland displays, this command switches which output is
+actively captured by wayvnc. This operates in 2 different modes, depending on
+which parameters are supplied:
+
+*cycle=next|prev*
+	Cycle to the next/prev output in the output list, wrapping back to the
+	first/last if the end of the list is reached.
+
+*switch-to=output-name*
+	Switch to a specific output by name.
+
+## IPC MESSAGE FORMAT
+
+The *wayvncctl(1)* command line utility will construct properly-formatted json
+ipc messages, but any client will work. The client initiates the connection and
+sends one or more request objects, each of which will receive a corresponding
+response object.
+
+*Note* This message format is unstable and may change substantially over the
+next few releases.
+
+_REQUEST_
+
+The general form of a json-ipc request message
+is:
+
+```
+{
+	"method": "command-name",
+	"id": 123,
+	"params": {
+		"key1": "value1",
+		"key2": "value2",
+	}
+}
+```
+
+The *method* is the name of the command to be executed. Use the *help* method to
+query a list of all valid method names.
+
+The *id* field is optional and may be any valid json number or string. If
+provided, the response to this request will contain the identical id value,
+which the client may use to coordinate multiple requests and responses.
+
+The *params* object supplies optional parameters on a per-method basis, and may
+be omitted if empty.
+
+_RESPONSE_
+
+```
+{
+	"id": 123,
+	"code": 0,
+	"data": {
+		...
+	}
+}
+```
+
+If the request had an id, the response will have an identical value for *id*.
+
+The numerical *code* provides an indication of how the request was handled. A
+value of *0* always signifies success. Any other value means failure, and varies
+depending on the method in question.
+
+The *data* object contains method-specific return data. This may be structured
+data in response to a query, a simple error string in the case of a failed
+request, or it may be omitted entirely if the error code alone is sufficient.
+
 # ENVIRONMENT
 
 The following environment variables have an effect on wayvnc:
@@ -158,6 +257,9 @@ _WAYLAND_DISPLAY_
 
 _XDG_CONFIG_HOME_
 	Specifies the location of configuration files.
+
+_XDG_RUNTIME_DIR_
+	Specifies the default location for the wayvncctl control socket.
 
 # FAQ
 
@@ -210,3 +312,7 @@ _XDG_CONFIG_HOME_
 Maintained by Andri Yngvason <andri@yngvason.is>. Up-to-date sources can be
 found at https://github.com/any1/wayvnc and bugs reports or patches can be
 submitted to GitHub's issue tracker.
+
+# SEE ALSO
+
+*wayvncctl(1)*

--- a/wayvncctl.scd
+++ b/wayvncctl.scd
@@ -1,0 +1,82 @@
+wayvncctl(1)
+
+# NAME
+
+wayvncctl - A control client for wayvnc(1)
+
+# SYNOPSIS
+
+*wayvncctl* [options] [command [--parameter value ...]]
+
+# OPTIONS
+
+*-S, --socket=<path>*
+	Set wayvnc control socket path. Default: $XDG_RUNTIME_DIR/wayvncctl
+	or /tmp/wayvncctl-$UID
+
+*-V, --version*
+	Show version info.
+
+*-v,--verbose*
+	Be more verbose.
+
+*-h, --help*
+	Get help.
+
+# DESCRIPTION
+
+*wayvnc(1)* allows runtime interaction via a unix socket json-ipc mechanism.
+This command line utility provides easy interaction with those commands.
+
+For a full list of currently supported commands, see
+*wayvnc(1)* section _IPC COMMANDS_, or use the
+*wayvncctl help* command.
+
+# EXAMPLES
+
+Query the server for all available command names:
+
+```
+$ wayvncctl help
+{
+    "commands": [
+        "help",
+        "version",
+        "set-output",
+	...
+    ]
+}
+```
+
+Get help on the "help" command:
+
+```
+$ wayvncctl help --command help
+{
+    "help": {
+        "description": "List all commands, or show usage of a specific command",
+        "params": [
+            {
+                "command": "The command to show (optional)"
+            }
+        ]
+    }
+}
+```
+
+Cycle to the next active output:
+
+```
+$ wayvncctl set-output --cycle=forward
+```
+
+# ENVIRONMENT
+
+The following environment variables have an effect on wayvncctl:
+
+_XDG_RUNTIME_DIR_
+	Specifies the default location for the wayvncctl control socket.
+
+# SEE ALSO
+
+*wayvnc(1)*

--- a/wayvncctl.scd
+++ b/wayvncctl.scd
@@ -14,6 +14,9 @@ wayvncctl - A control client for wayvnc(1)
 	Set wayvnc control socket path. Default: $XDG_RUNTIME_DIR/wayvncctl
 	or /tmp/wayvncctl-$UID
 
+*-j, --json*
+	Produce json output to stdout.
+
 *-V, --version*
 	Show version info.
 
@@ -38,30 +41,25 @@ Query the server for all available command names:
 
 ```
 $ wayvncctl help
-{
-    "commands": [
-        "help",
-        "version",
-        "set-output",
-	...
-    ]
-}
+Allowed commands:
+  - help
+  - version
+  - set-output
+
+Run 'wayvncctl command-name --help' for command-specific details.
 ```
 
 Get help on the "help" command:
 
 ```
-$ wayvncctl help --command help
-{
-    "help": {
-        "description": "List all commands, or show usage of a specific command",
-        "params": [
-            {
-                "command": "The command to show (optional)"
-            }
-        ]
-    }
-}
+$ wayvncctl help --help
+Usage: wayvncctl [options] help [params]
+
+List all commands, or show usage of a specific command
+
+Parameters:
+  --command=...
+    The command to show (optional)
 ```
 
 Cycle to the next active output:

--- a/wayvncctl.scd
+++ b/wayvncctl.scd
@@ -2,7 +2,7 @@ wayvncctl(1)
 
 # NAME
 
-wayvncctl - A control client for wayvnc(1)
+wayvncctl - A command line control lient for wayvnc(1)
 
 # SYNOPSIS
 
@@ -24,7 +24,8 @@ wayvncctl - A control client for wayvnc(1)
 	Be more verbose.
 
 *-h, --help*
-	Get help.
+	Get help about the wayvncctl command itself (lists these options). Does
+	not connect to the wayvncctl control socket.
 
 # DESCRIPTION
 
@@ -32,12 +33,18 @@ wayvncctl - A control client for wayvnc(1)
 This command line utility provides easy interaction with those commands.
 
 For a full list of currently supported commands, see
-*wayvnc(1)* section _IPC COMMANDS_, or use the
+*wayvnc(1)* section _IPC COMMANDS_, or run the
 *wayvncctl help* command.
+
+Running *wayvncctl help* contacts the server over the control socket and returns
+a list of the available commands.
+
+Running *wayvncctl command-name --help* returns a description of the server-side
+command and its available parameters.
 
 # EXAMPLES
 
-Query the server for all available command names:
+Query the server for all available IPC command names:
 
 ```
 $ wayvncctl help
@@ -49,23 +56,35 @@ Allowed commands:
 Run 'wayvncctl command-name --help' for command-specific details.
 ```
 
-Get help on the "help" command:
+Get help on the "set-output" IPC command:
 
 ```
-$ wayvncctl help --help
-Usage: wayvncctl [options] help [params]
+$ wayvncctl set-output --help
+Usage: wayvncctl [options] set-output [params]
 
-List all commands, or show usage of a specific command
+Switch the actively captured output
 
 Parameters:
-  --command=...
-    The command to show (optional)
+  --switch-to=...
+    The specific output name to capture
+
+  --cycle=...
+    Either "next" or "prev"
+
+Run 'wayvncctl --help' for allowed options
 ```
 
 Cycle to the next active output:
 
 ```
-$ wayvncctl set-output --cycle=forward
+$ wayvncctl set-output --cycle=next
+```
+
+Get json-formatted version information:
+
+```
+$ wayvncctl --json version
+{"wayvnc":"v0.5.0","neatvnc":"v0.5.1","aml":"v0.2.2"}
 ```
 
 # ENVIRONMENT


### PR DESCRIPTION
- Refactor pointer initialization code
- Refactor output selection code
- Add output_cycle to get next/prev outputs
- Add functions to switch outputs on the fly
- Switch to previous output if current output disappears
- Add json-ipc message plumbing
- Add ctl control socket and initial command infrastructure
- Refactor some common utilities out of main
- Add ctl-client code
- Add initial wayvncctl executable
- Add wayvnctl help command
- Add wayvncctl version command
- Manpage updates for wayvnc and wayvncctl

I have read and understood CONTRIBUTING.md and its associated documents.
