### PR TITLE
wayvncctl events

### DIFF
--- a/examples/event-watcher
+++ b/examples/event-watcher
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+WAYVNCCTL=${WAYVNCCTL:-wayvncctl}
+
+connection_count_now() {
+    echo "Total clients: $count"
+}
+
+while IFS= read -r EVT; do
+    case "$(jq -r '.method' <<<"$EVT")" in
+        client-*onnected)
+            count=$(jq -r '.params.connection_count' <<<"$EVT")
+            connection_count_now "$count"
+            ;;
+    esac
+done < <("$WAYVNCCTL" --json event-receive)

--- a/include/ctl-server.h
+++ b/include/ctl-server.h
@@ -37,3 +37,15 @@ void* ctl_server_userdata(struct ctl*);
 
 struct cmd_response* cmd_ok(void);
 struct cmd_response* cmd_failed(const char* fmt, ...);
+
+void ctl_server_event_connected(struct ctl*,
+		const char* client_id,
+		const char* client_hostname,
+		const char* client_username,
+		int new_connection_count);
+
+void ctl_server_event_disconnected(struct ctl*,
+		const char* client_id,
+		const char* client_hostname,
+		const char* client_username,
+		int new_connection_count);

--- a/include/json-ipc.h
+++ b/include/json-ipc.h
@@ -52,6 +52,8 @@ struct jsonipc_request* jsonipc_request_parse_new(json_t* root,
 		struct jsonipc_error* err);
 struct jsonipc_request* jsonipc_request_new(const char* method, json_t* params);
 struct jsonipc_request* jsonipc_event_new(const char* method, json_t* params);
+struct jsonipc_request* jsonipc_event_parse_new(json_t* root,
+		struct jsonipc_error* err);
 json_t* jsonipc_request_pack(struct jsonipc_request*, json_error_t* err);
 void jsonipc_request_destroy(struct jsonipc_request*);
 

--- a/include/json-ipc.h
+++ b/include/json-ipc.h
@@ -51,6 +51,7 @@ void jsonipc_error_cleanup(struct jsonipc_error*);
 struct jsonipc_request* jsonipc_request_parse_new(json_t* root,
 		struct jsonipc_error* err);
 struct jsonipc_request* jsonipc_request_new(const char* method, json_t* params);
+struct jsonipc_request* jsonipc_event_new(const char* method, json_t* params);
 json_t* jsonipc_request_pack(struct jsonipc_request*, json_error_t* err);
 void jsonipc_request_destroy(struct jsonipc_request*);
 

--- a/src/ctl-client.c
+++ b/src/ctl-client.c
@@ -47,7 +47,7 @@ struct ctl_client {
 
 	char read_buffer[512];
 	size_t read_len;
-	
+
 	bool wait_for_events;
 
 	int fd;

--- a/src/json-ipc.c
+++ b/src/json-ipc.c
@@ -111,6 +111,12 @@ struct jsonipc_request* jsonipc_event_new(const char* method, json_t* params)
 	return jsonipc_request__new(method, params, NULL);
 }
 
+struct jsonipc_request* jsonipc_event_parse_new(json_t* root,
+		struct jsonipc_error* err)
+{
+	return jsonipc_request_parse_new(root, err);
+}
+
 json_t* jsonipc_request_pack(struct jsonipc_request* self, json_error_t* err)
 {
 	return json_pack_ex(err, 0, "{s:s, s:O*, s:O*}",

--- a/src/json-ipc.c
+++ b/src/json-ipc.c
@@ -89,15 +89,26 @@ failure:
 	return NULL;
 }
 
-static int request_id = 1;
-struct jsonipc_request* jsonipc_request_new(const char* method, json_t* params)
+struct jsonipc_request* jsonipc_request__new(const char* method, json_t* params,
+		json_t* id)
 {
 	struct jsonipc_request* ipc = calloc(1, sizeof(*ipc));
 	ipc->method = method;
 	ipc->params = params;
 	json_incref(ipc->params);
-	ipc->id = json_integer(request_id++);
+	ipc->id = id;
 	return ipc;
+}
+
+static int request_id = 1;
+struct jsonipc_request* jsonipc_request_new(const char* method, json_t* params)
+{
+	return jsonipc_request__new(method, params, json_integer(request_id++));
+}
+
+struct jsonipc_request* jsonipc_event_new(const char* method, json_t* params)
+{
+	return jsonipc_request__new(method, params, NULL);
 }
 
 json_t* jsonipc_request_pack(struct jsonipc_request* self, json_error_t* err)

--- a/src/main.c
+++ b/src/main.c
@@ -844,6 +844,14 @@ static void on_client_cleanup(struct nvnc_client* client)
 	self->nr_clients--;
 	nvnc_log(NVNC_LOG_DEBUG, "Client disconnected, new client count: %d",
 			self->nr_clients);
+
+	char id[11];
+	snprintf(id, 11, "%p", nvnc);
+	ctl_server_event_disconnected(self->ctl, id,
+			nvnc_client_get_hostname(client),
+			nvnc_client_get_auth_username(client),
+			self->nr_clients);
+
 	if (self->nr_clients == 0) {
 		nvnc_log(NVNC_LOG_INFO, "Stopping screen capture");
 		screencopy_stop(&self->screencopy);
@@ -864,6 +872,13 @@ static void on_client_new(struct nvnc_client* client)
 	self->nr_clients++;
 	nvnc_set_client_cleanup_fn(client, on_client_cleanup);
 	nvnc_log(NVNC_LOG_DEBUG, "Client connected, new client count: %d",
+			self->nr_clients);
+
+	char id[11];
+	snprintf(id, 11, "%p", nvnc);
+	ctl_server_event_connected(self->ctl, id,
+			nvnc_client_get_hostname(client),
+			nvnc_client_get_auth_username(client),
 			self->nr_clients);
 }
 

--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -176,6 +176,16 @@ information. Much like the _-V_ option, the response data will contain the
 version numbers of wayvnc, as well as the versions of the neatvnc and aml
 components.
 
+_EVENT-RECEIVE_
+
+The *event-receive* command registers for asynchronous server events. See the
+_EVENTS_ section below for details on the event message format, and the _IPC
+EVENTS_ section below for a description of all possible server events.
+
+Event registration registers for all available server eve ts and is scoped to
+the current connection only. If a client disconnects and reconnects, it must
+re-register for events.
+
 _SET-OUTPUT_
 
 For multi-output wayland displays, this command switches which output is
@@ -188,6 +198,45 @@ which parameters are supplied:
 
 *switch-to=output-name*
 	Switch to a specific output by name.
+
+## IPC EVENTS
+
+_CLIENT-CONNECTED_
+
+The *client-connected* event is sent when a new VNC client connects to wayvnc.
+
+Parameters:
+
+*id=...*
+	A unique identifier for this client.
+
+*connection_count=...*
+	The total number of connected VNC clients including this one.
+
+*hostname=...*
+	The hostname or IP of this client. May be null.
+
+*username=...*
+	The username used to authenticate this client. May be null.
+
+_CLIENT-DISCONNECTED_
+
+The *client-disconnected* event is sent when a VNC cliwnt disconnects from
+wayvnc.
+
+Parameters:
+
+*id=...*
+	A unique identifier for this client.
+
+*connection_count=...*
+	The total number of connected VNC clients not including this one.
+
+*hostname=...*
+	The hostname or IP of this client. May be null.
+
+*username=...*
+	The username used to authenticate this client. May be null.
 
 ## IPC MESSAGE FORMAT
 
@@ -246,6 +295,30 @@ depending on the method in question.
 The *data* object contains method-specific return data. This may be structured
 data in response to a query, a simple error string in the case of a failed
 request, or it may be omitted entirely if the error code alone is sufficient.
+
+_EVENTS_
+
+Events are aaynchronous messages sent from a server to all registered clients.
+The message format is identical to a _REQUEST_, but without an "id" field, and a
+client must not send a response.
+
+Example event message:
+
+```
+{
+	"method": "event-name",
+	"params": {
+		"key1": "value1",
+		"key2": "value2",
+	}
+}
+```
+
+In order to receive any events, a client must first register to receive them by
+sending a _event-receive_ request IPC. Once the success response has been sent
+by the server, the client must expect that asynchronous event messages may be
+sent by the server at any time, even between a request and the associated
+response.
 
 # ENVIRONMENT
 

--- a/wayvncctl.scd
+++ b/wayvncctl.scd
@@ -46,9 +46,36 @@ command and its available parameters.
 
 While *wayvncctl* normally terminates after sending one request and receiving
 the corresponding reply, the *event-receive* command acts differently. Instead
-of exiting immediately, *wayvncctl* waits for any events fr the server, printing
-each to stdout as they arrive. This mode of operation will block until either
-it receives a signal to terminate, or until the wayvnc server terminates.
+of exiting immediately, *wayvncctl* waits for any events from the server,
+printing each to stdout as they arrive. This mode of operation will block until
+either it receives a signal to terminate, or until the wayvnc server terminates.
+
+In _--json_ mode, each event is printed on one line, with a newline character at
+the end, for ease in scripting:
+
+```
+$ wayvncctl --json event-receive
+{"method":"client-connected","params":{"id":"0x10ef670","hostname":null,"username":null,"connection_count":1}}
+{"method":"client-disconnected","params":{"id":"0x10ef670","hostname":null,"username":null,"connection_count":0}}
+```
+
+The default human-readible output is a multi-line yaml-like format, with two
+newline characters between each event:
+
+```
+$ wayvncctl event-receive
+
+client-connected:
+  id: 0x10ef670
+  hostname: 192.168.1.18
+  connection_count: 1
+
+client-disconnected:
+  id: 0x10ef670
+  hostname: 192.168.1.18
+  connection_count: 0
+
+```
 
 # EXAMPLES
 

--- a/wayvncctl.scd
+++ b/wayvncctl.scd
@@ -42,6 +42,14 @@ a list of the available commands.
 Running *wayvncctl command-name --help* returns a description of the server-side
 command and its available parameters.
 
+# ASYNCHRONOUS EVENTS
+
+While *wayvncctl* normally terminates after sending one request and receiving
+the corresponding reply, the *event-receive* command acts differently. Instead
+of exiting immediately, *wayvncctl* waits for any events fr the server, printing
+each to stdout as they arrive. This mode of operation will block until either
+it receives a signal to terminate, or until the wayvnc server terminates.
+
 # EXAMPLES
 
 Query the server for all available IPC command names:

--- a/wayvncctl.scd
+++ b/wayvncctl.scd
@@ -122,6 +122,25 @@ $ wayvncctl --json version
 {"wayvnc":"v0.5.0","neatvnc":"v0.5.1","aml":"v0.2.2"}
 ```
 
+A script that takes an action for each client connect and disconnect event:
+
+```
+#!/bin/bash
+
+connection_count_now() {
+    echo "Total clients: $count"
+}
+
+while IFS= read -r EVT; do
+    case "$(jq -r '.method' <<<"$EVT")" in
+        client-*onnected)
+            count=$(jq -r '.params.connection_count' <<<"$EVT")
+            connection_count_now "$count"
+            ;;
+    esac
+done < <(wayvncctl --json event-receive)
+```
+
 # ENVIRONMENT
 
 The following environment variables have an effect on wayvncctl:


### PR DESCRIPTION
Adds server->client broadcast events

Read wayvnc.scd and wayvncctl.scd for an overview.

- Ensure fatal errors are sent first
- Add jsonipc event message constructor
- Add server event infrastructure
- Added event help text
- Add generic yaml-like printing of event data
- Add example event-watcher script

I have read and understood CONTRIBUTING.md and its associated documents.
