### PR TITLE
Introduce wayvncctl startup amd shutdown events

### DIFF
--- a/examples/event-watcher
+++ b/examples/event-watcher
@@ -3,7 +3,7 @@
 WAYVNCCTL=${WAYVNCCTL:-wayvncctl}
 
 connection_count_now() {
-    echo "Total clients: $count"
+    echo "Total clients: $1"
 }
 
 while IFS= read -r EVT; do
@@ -12,5 +12,13 @@ while IFS= read -r EVT; do
             count=$(jq -r '.params.connection_count' <<<"$EVT")
             connection_count_now "$count"
             ;;
+        wayvnc-shutdown)
+            echo "wayvncctl is no longer running"
+            connection_count_now 0
+            ;;
+        wayvnc-startup)
+            echo "Ready to receive wayvnc events"
+            ;;
     esac
 done < <("$WAYVNCCTL" --wait --reconnect --json event-receive)
+

--- a/wayvncctl.scd
+++ b/wayvncctl.scd
@@ -85,6 +85,24 @@ client-disconnected:
 
 ```
 
+## SPECIAL LOCAL EVENT TYPES
+
+Especially useful when using _--wait_ or _--reconnect_ mode, wayvncctl will
+generate 2 additional events not documented in *wayvnc(1)*:
+
+*wayvnc-startup*
+	Sent when a successful wayvnc control connection is established and
+	event registration has succeeded, both upon initial startup and on
+	subsequent registrations with _--reconnect_.
+
+	No paramerers.
+
+*wayvnc-shutdown*
+	Sent when the wayvnc control connection is dropped, usually due to
+	wayvnc exiting.
+
+	No paramerers.
+
 # EXAMPLES
 
 Query the server for all available IPC command names:
@@ -136,7 +154,7 @@ A script that takes an action for each client connect and disconnect event:
 #!/bin/bash
 
 connection_count_now() {
-    echo "Total clients: $count"
+    echo "Total clients: $1"
 }
 
 while IFS= read -r EVT; do
@@ -145,6 +163,9 @@ while IFS= read -r EVT; do
             count=$(jq -r '.params.connection_count' <<<"$EVT")
             connection_count_now "$count"
             ;;
+        wayvnc-shutdown)
+            connection_count_now 0
+	    ;;
     esac
 done < <(wayvncctl --wait --reconnect --json event-receive)
 ```


### PR DESCRIPTION
Especially useful when using `--wait` or `--reconnect` mode, wayvncctl will
generate 2 additional events not documented in *wayvnc(1)*:

*wayvnc-startup*
	Sent when a successful wayvnc control connection is established and
	event registration has succeeded, both upon initial startup and on
	subsequent registrations with `--reconnect`.

	No paramerers.

*wayvnc-shutdown*
	Sent when the wayvnc control connection is dropped, usually due to
	wayvnc exiting.

	No paramerers.
