### PR TITLE
Fix segfault if running wayvncctl with no args

### DIFF
--- a/src/wayvncctl.c
+++ b/src/wayvncctl.c
@@ -127,6 +127,8 @@ int main(int argc, char* argv[])
 		}
 	}
 	argc -= optind;
+	if (argc <= 0)
+		return wayvncctl_usage(stderr, 1);
 	argv = &argv[optind];
 
 	ctl_client_debug_log(verbose);


### PR DESCRIPTION

I have read and understood CONTRIBUTING.md and its associated documents.
