### PR TITLE
Add wayvncctl get-outputs, disconnect-client, and wayvnc-exit commands

### DIFF
--- a/include/ctl-server.h
+++ b/include/ctl-server.h
@@ -76,3 +76,6 @@ void ctl_server_event_disconnected(struct ctl*,
 		const char* client_hostname,
 		const char* client_username,
 		int new_connection_count);
+
+void ctl_server_event_capture_changed(struct ctl*,
+		const char* captured_output);

--- a/include/ctl-server.h
+++ b/include/ctl-server.h
@@ -41,6 +41,8 @@ struct ctl_server_actions {
 			enum output_cycle_direction direction);
 	struct cmd_response* (*on_output_switch)(struct ctl*,
 			const char* output_name);
+	struct cmd_response* (*on_disconnect_client)(struct ctl*,
+			const char* id);
 
 	// Return number of elements created
 	// Allocate 'clients' array or set ton ULL if none

--- a/include/ctl-server.h
+++ b/include/ctl-server.h
@@ -43,6 +43,7 @@ struct ctl_server_actions {
 			const char* output_name);
 	struct cmd_response* (*on_disconnect_client)(struct ctl*,
 			const char* id);
+	struct cmd_response* (*on_wayvnc_exit)(struct ctl*);
 
 	// Return number of elements created
 	// Allocate 'clients' array or set ton ULL if none

--- a/include/ctl-server.h
+++ b/include/ctl-server.h
@@ -27,6 +27,14 @@ struct ctl_server_vnc_client {
 	char username[256];
 };
 
+struct ctl_server_output {
+	char name[65];
+	char description[128];
+	unsigned height;
+	unsigned width;
+	bool captured;
+};
+
 struct ctl_server_actions {
 	void* userdata;
 	struct cmd_response* (*on_output_cycle)(struct ctl*,
@@ -39,6 +47,12 @@ struct ctl_server_actions {
 	// Receiver will free(clients) when done.
 	int (*get_client_list)(struct ctl*,
 			struct ctl_server_vnc_client** clients);
+
+	// Return number of elements created
+	// Allocate 'outputs' array or set to NULL if none
+	// Receiver will free(outputs) when done.
+	int (*get_output_list)(struct ctl*,
+			struct ctl_server_output** outputs);
 };
 
 struct ctl* ctl_server_new(const char* socket_path,

--- a/src/ctl-client.c
+++ b/src/ctl-client.c
@@ -412,6 +412,29 @@ static void pretty_client_list(json_t* data)
 	}
 }
 
+static void pretty_output_list(json_t* data)
+{
+	int n = json_array_size(data);
+	printf("There %s %d output%s%s\n", (n == 1) ? "is" : "are",
+			n, (n == 1) ? "" : "s", (n > 0) ? ":" : ".");
+	int i;
+	json_t* value;
+	json_array_foreach(data, i, value) {
+		char* name = NULL;
+		char* description = NULL;
+		int height = -1;
+		int width = -1;
+		int captured = false;
+		json_unpack(value, "{s:s, s:s, s:i, s:i, s:b}", "name", &name, 
+				"description", &description,
+				"height", &height,
+				"width", &width,
+				"captured", &captured);
+		printf("%s output[%s]: %s (%dx%d)\n",
+				captured ? "*" : " ", name, description, width,
+				height);
+	}
+}
 static void pretty_print(json_t* data,
 		struct jsonipc_request* request)
 {
@@ -422,6 +445,8 @@ static void pretty_print(json_t* data,
 		pretty_version(data);
 	else if (strcmp(method, "get-clients") == 0)
 		pretty_client_list(data);
+	else if (strcmp(method, "get-outputs") == 0)
+		pretty_output_list(data);
 	else
 		json_dumpf(data, stdout, JSON_INDENT(2));
 }

--- a/src/ctl-server.c
+++ b/src/ctl-server.c
@@ -971,11 +971,12 @@ json_t* pack_connection_event_params(
 			"connection_count", new_connection_count);
 }
 
-int ctl_server_enqueue_event(struct ctl* self, const char* event_name,
+int ctl_server_enqueue_event(struct ctl* self, enum event_type evt_type,
 		json_t* params)
 {
+	const char* event_name = evt_list[evt_type].name;
 	char* param_str = json_dumps(params, JSON_COMPACT);
-	nvnc_log(NVNC_LOG_DEBUG, "Enqueueing %s event: {%s", event_name, param_str);
+	nvnc_log(NVNC_LOG_DEBUG, "Enqueueing %s event: %s", event_name, param_str);
 	free(param_str);
 	struct jsonipc_request* event = jsonipc_event_new(event_name, params);
 	json_decref(params);
@@ -1007,7 +1008,7 @@ int ctl_server_enqueue_event(struct ctl* self, const char* event_name,
 }
 
 static void ctl_server_event_connect(struct ctl* self,
-		bool connected,
+		enum event_type evt_type,
 		const char* client_id,
 		const char* client_hostname,
 		const char* client_username,
@@ -1015,9 +1016,7 @@ static void ctl_server_event_connect(struct ctl* self,
 {
 	json_t* params = pack_connection_event_params(client_id, client_hostname,
 			client_username, new_connection_count);
-	ctl_server_enqueue_event(self,
-			connected ? "client-connected" : "client-disconnected",
-			params);
+	ctl_server_enqueue_event(self, evt_type, params);
 }
 
 void ctl_server_event_connected(struct ctl* self,
@@ -1026,8 +1025,8 @@ void ctl_server_event_connected(struct ctl* self,
 		const char* client_username,
 		int new_connection_count)
 {
-	ctl_server_event_connect(self, true, client_id, client_hostname,
-			client_username, new_connection_count);
+	ctl_server_event_connect(self, EVT_CLIENT_CONNECTED, client_id,
+			client_hostname, client_username, new_connection_count);
 }
 
 void ctl_server_event_disconnected(struct ctl* self,
@@ -1036,6 +1035,6 @@ void ctl_server_event_disconnected(struct ctl* self,
 		const char* client_username,
 		int new_connection_count)
 {
-	ctl_server_event_connect(self, false, client_id, client_hostname,
-			client_username, new_connection_count);
+	ctl_server_event_connect(self, EVT_CLIENT_DISCONNECTED, client_id,
+			client_hostname, client_username, new_connection_count);
 }

--- a/src/ctl-server.c
+++ b/src/ctl-server.c
@@ -212,7 +212,6 @@ static struct cmd_help* cmd_help_new(json_t* args,
 		return NULL;
 	}
 	struct cmd_help* cmd = calloc(1, sizeof(*cmd));
-	cmd->cmd.type = CMD_HELP;
 	if (command) {
 		strlcpy(cmd->id, command, sizeof(cmd->id));
 		cmd->id_is_command = true;
@@ -241,7 +240,6 @@ static struct cmd_set_output* cmd_set_output_new(json_t* args,
 		return NULL;
 	}
 	struct cmd_set_output* cmd = calloc(1, sizeof(*cmd));
-	cmd->cmd.type = CMD_SET_OUTPUT;
 	if (target) {
 		strlcpy(cmd->target, target, sizeof(cmd->target));
 	} else if (cycle) {
@@ -296,7 +294,6 @@ static struct cmd* parse_command(struct jsonipc_request* ipc,
 	case CMD_GET_CLIENTS:
 	case CMD_GET_OUTPUTS:
 		cmd = calloc(1, sizeof(*cmd));
-		cmd->type = cmd_type;
 		break;
 	case CMD_UNKNOWN:
 		jsonipc_error_set_new(err, ENOENT,
@@ -305,7 +302,9 @@ static struct cmd* parse_command(struct jsonipc_request* ipc,
 					jprintf("Unknown command \"%s\"",
 						ipc->method),
 					"commands", list_allowed_commands()));
+		return NULL;
 	}
+	cmd->type = cmd_type;
 	return cmd;
 }
 

--- a/src/ctl-server.c
+++ b/src/ctl-server.c
@@ -49,6 +49,7 @@ enum cmd_type {
 	CMD_GET_CLIENTS,
 	CMD_GET_OUTPUTS,
 	CMD_DISCONNECT_CLIENT,
+	CMD_WAYVNC_EXIT,
 	CMD_UNKNOWN,
 };
 #define CMD_LIST_LEN CMD_UNKNOWN
@@ -112,6 +113,10 @@ static struct cmd_info cmd_list[] = {
 			{"id", "The ID of the client to disconnect"},
 			{NULL, NULL},
 		}
+	},
+	[CMD_WAYVNC_EXIT] = { "wayvnc-exit",
+		"Disconnect all clients and shut down wayvnc",
+		{{NULL,NULL}},
 	},
 };
 
@@ -333,6 +338,7 @@ static struct cmd* parse_command(struct jsonipc_request* ipc,
 	case CMD_EVENT_RECEIVE:
 	case CMD_GET_CLIENTS:
 	case CMD_GET_OUTPUTS:
+	case CMD_WAYVNC_EXIT:
 		cmd = calloc(1, sizeof(*cmd));
 		break;
 	case CMD_UNKNOWN:
@@ -538,6 +544,9 @@ static struct cmd_response* ctl_server_dispatch_cmd(struct ctl* self,
 		response = self->actions.on_disconnect_client(self, c->id);
 		break;
 		}
+	case CMD_WAYVNC_EXIT:
+		response = self->actions.on_wayvnc_exit(self);
+		break;
 	case CMD_VERSION:
 		response = generate_version_object();
 		break;

--- a/src/ctl-server.c
+++ b/src/ctl-server.c
@@ -56,6 +56,7 @@ enum cmd_type {
 enum event_type {
 	EVT_CLIENT_CONNECTED,
 	EVT_CLIENT_DISCONNECTED,
+	EVT_CAPTURE_CHANGED,
 	EVT_UNKNOWN,
 };
 #define EVT_LIST_LEN EVT_UNKNOWN
@@ -130,6 +131,14 @@ static struct cmd_info evt_list[] = {
 		"Sent when a vnc client disconnects from wayvnc",
 		{ CLIENT_EVENT_PARAMS("not including") }
 	},
+	[EVT_CAPTURE_CHANGED] = {"capture-changed",
+		"Sent when wayvnc changes which output is captured",
+		{
+			{"output", "The name of the output now being captured"},
+			{NULL, NULL},
+		},
+	},
+
 };
 
 struct cmd {
@@ -1037,4 +1046,11 @@ void ctl_server_event_disconnected(struct ctl* self,
 {
 	ctl_server_event_connect(self, EVT_CLIENT_DISCONNECTED, client_id,
 			client_hostname, client_username, new_connection_count);
+}
+
+void ctl_server_event_capture_changed(struct ctl* self,
+		const char* captured_output)
+{
+	ctl_server_enqueue_event(self, EVT_CAPTURE_CHANGED,
+			json_pack("{s:s}", "output", captured_output));
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1087,6 +1087,8 @@ void set_selected_output(struct wayvnc* self, struct output* output) {
 	self->screencopy.wl_output = output->wl_output;
 	output->on_dimension_change = on_output_dimension_change;
 	output->userdata = self;
+	if (self->ctl)
+		ctl_server_event_capture_changed(self->ctl, output->name);
 	log_selected_output(self);
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -493,6 +493,30 @@ static int get_client_list(struct ctl* ctl,
 	return self->nr_clients;
 }
 
+static int get_output_list(struct ctl* ctl,
+		struct ctl_server_output** outputs)
+{
+	struct wayvnc* self = ctl_server_userdata(ctl);
+	int n = wl_list_length(&self->outputs);
+	if (n == 0) {
+		*outputs = NULL;
+		return 0;
+	}
+	*outputs = calloc(n, sizeof(**outputs));
+	struct output* output;
+	struct ctl_server_output* item = *outputs;
+	wl_list_for_each(output, &self->outputs, link) {
+		strlcpy(item->name, output->name, sizeof(item->name));
+		strlcpy(item->description, output->description,
+				sizeof(item->description));
+		item->height = output->height;
+		item->width = output->width;
+		item->captured = (output->id == self->selected_output->id);
+		item++;
+	}
+	return n;
+}
+
 int init_main_loop(struct wayvnc* self)
 {
 	struct aml* loop = aml_get_default();
@@ -1334,6 +1358,7 @@ int main(int argc, char* argv[])
 		.on_output_cycle = on_output_cycle,
 		.on_output_switch = on_output_switch,
 		.get_client_list = get_client_list,
+		.get_output_list = get_output_list,
 	};
 	self.ctl = ctl_server_new(socket_path, &ctl_actions);
 	if (!self.ctl)

--- a/src/main.c
+++ b/src/main.c
@@ -539,6 +539,14 @@ static struct cmd_response* on_disconnect_client(struct ctl* ctl,
 	return cmd_failed("No such client with ID \"%s\"", id_string);
 }
 
+static struct cmd_response* on_wayvnc_exit(struct ctl* ctl)
+{
+	struct wayvnc* self = ctl_server_userdata(ctl);
+	nvnc_log(NVNC_LOG_WARNING, "Shutting down via control socket command");
+	wayvnc_exit(self);
+	return cmd_ok();
+}
+
 int init_main_loop(struct wayvnc* self)
 {
 	struct aml* loop = aml_get_default();
@@ -1384,6 +1392,7 @@ int main(int argc, char* argv[])
 		.get_client_list = get_client_list,
 		.get_output_list = get_output_list,
 		.on_disconnect_client = on_disconnect_client,
+		.on_wayvnc_exit = on_wayvnc_exit,
 	};
 	self.ctl = ctl_server_new(socket_path, &ctl_actions);
 	if (!self.ctl)

--- a/src/main.c
+++ b/src/main.c
@@ -517,6 +517,28 @@ static int get_output_list(struct ctl* ctl,
 	return n;
 }
 
+static struct cmd_response* on_disconnect_client(struct ctl* ctl,
+		const char* id_string)
+{
+	int id = atoi(id_string);
+	if (id <= 0)
+		return cmd_failed("Invalid client ID \"%s\"", id_string);
+
+	struct wayvnc* self = ctl_server_userdata(ctl);
+	for (struct nvnc_client* nvnc_client = nvnc_client_first(self->nvnc);
+			nvnc_client;
+			nvnc_client = nvnc_client_next(nvnc_client)) {
+		struct wayvnc_client* client = nvnc_get_userdata(nvnc_client);
+		if (client->id == id) {
+			nvnc_log(NVNC_LOG_WARNING, "Disconnecting client %d via control socket command",
+					client->id);
+			nvnc_client_close(nvnc_client);
+			return cmd_ok();
+		}
+	}
+	return cmd_failed("No such client with ID \"%s\"", id_string);
+}
+
 int init_main_loop(struct wayvnc* self)
 {
 	struct aml* loop = aml_get_default();
@@ -1359,6 +1381,7 @@ int main(int argc, char* argv[])
 		.on_output_switch = on_output_switch,
 		.get_client_list = get_client_list,
 		.get_output_list = get_output_list,
+		.on_disconnect_client = on_disconnect_client,
 	};
 	self.ctl = ctl_server_new(socket_path, &ctl_actions);
 	if (!self.ctl)

--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -203,6 +203,16 @@ which parameters are supplied:
 *switch-to=output-name*
 	Switch to a specific output by name.
 
+_DISCONNECT_CLIENT_
+
+The *disconnect-client* command disconnects a single VNC client.
+
+Parameters:
+
+*id*
+	Required: The ID of the client to disconnect.  This ID can be found from the
+	_GET-CLIENTS_ command or receipt of a _CLIENT-CONNECTED_ event.
+
 _GET-CLIENTS_
 
 The *get-clients* command retrieves a list of all VNC clients currently

--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -68,11 +68,15 @@ is also possible to run wayvnc without a physical display attached.
 
 ## MULTIPLE OUTPUTS
 
-If the Wayland session consists of  multiple outputs, only one will be captured.
+If the Wayland session consists of multiple outputs, only one will be captured.
 By default this will be the first one, but can be specified by the _-o_ command
 line argument. The argument accepts the short name such as _eDP-1_ or _DP-4_.
 Running wayvnc in verbose mode (_-v_) will display the names of all outputs on
-startup.
+startup, or you can query them at runtime via the *wayvncctl get-outputs*
+command.
+
+You can also change which output is being captured on the fly via the *wayvncctl
+set-output* command.
 
 # CONFIGURATION
 
@@ -203,6 +207,11 @@ _GET-CLIENTS_
 
 The *get-clients* command retrieves a list of all VNC clients currently
 connected to wayvnc.
+
+_GET-OUTPUTS_
+
+The *get-outputs* command retrieves a list of all outputs known to wayvnc and
+whether or not each one is currently being captured.
 
 ## IPC EVENTS
 

--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -213,6 +213,10 @@ Parameters:
 	Required: The ID of the client to disconnect.  This ID can be found from the
 	_GET-CLIENTS_ command or receipt of a _CLIENT-CONNECTED_ event.
 
+_WAYVNC_EXIT_
+
+The *wayvnc-exit* command disconnects all clients and shuts down wayvnc.
+
 _GET-CLIENTS_
 
 The *get-clients* command retrieves a list of all VNC clients currently

--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -262,6 +262,16 @@ Parameters:
 *username=...*
 	The username used to authenticate this client. May be null.
 
+_CAPTURE_CHANGED_
+
+The *capture-changed* event is sent when the currently captured output
+changes.
+
+Parameters:
+
+*output=...*
+	The name of the output now being captured.
+
 ## IPC MESSAGE FORMAT
 
 The *wayvncctl(1)* command line utility will construct properly-formatted json


### PR DESCRIPTION
Adds `get-outputs`, `disconnect-client`, and `wayvnc-exit` commands, plus a `capture-changed` event.

I have read and understood CONTRIBUTING.md and its associated documents.
