### PR TITLE
DPMS Support

### DIFF
--- a/include/output.h
+++ b/include/output.h
@@ -69,6 +69,7 @@ void output_set_xdg_output(struct output* output,
                            struct zxdg_output_v1* xdg_output);
 void output_set_wlr_output_power(struct output* output,
                            struct zwlr_output_power_v1* wlr_output_power);
+int output_set_power_state(struct output* output, enum output_power_state state);
 void output_list_destroy(struct wl_list* list);
 struct output* output_find_by_id(struct wl_list* list, uint32_t id);
 struct output* output_find_by_name(struct wl_list* list, const char* name);

--- a/include/output.h
+++ b/include/output.h
@@ -21,10 +21,20 @@
 #include <stdbool.h>
 
 struct zxdg_output_v1;
+struct zwlr_output_power_v1;
+
+enum output_power_state {
+	OUTPUT_POWER_UNKNOWN = 0,
+	OUTPUT_POWER_OFF,
+	OUTPUT_POWER_ON,
+};
+
+const char* output_power_state_name(enum output_power_state state);
 
 struct output {
 	struct wl_output* wl_output;
 	struct zxdg_output_v1* xdg_output;
+	struct zwlr_output_power_v1* wlr_output_power;
 	struct wl_list link;
 
 	uint32_t id;
@@ -41,12 +51,14 @@ struct output {
 	char model[256];
 	char name[256];
 	char description[256];
+	enum output_power_state power;
 
 	bool is_dimension_changed;
 	bool is_transform_changed;
 
 	void (*on_dimension_change)(struct output*);
 	void (*on_transform_change)(struct output*);
+	void (*on_power_change)(struct output*);
 
 	void* userdata;
 };
@@ -55,6 +67,8 @@ struct output* output_new(struct wl_output* wl_output, uint32_t id);
 void output_destroy(struct output* output);
 void output_set_xdg_output(struct output* output,
                            struct zxdg_output_v1* xdg_output);
+void output_set_wlr_output_power(struct output* output,
+                           struct zwlr_output_power_v1* wlr_output_power);
 void output_list_destroy(struct wl_list* list);
 struct output* output_find_by_id(struct wl_list* list, uint32_t id);
 struct output* output_find_by_name(struct wl_list* list, const char* name);

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -21,6 +21,7 @@ client_protocols = [
 	'xdg-output-unstable-v1.xml',
 	'linux-dmabuf-unstable-v1.xml',
 	'wlr-data-control-unstable-v1.xml',
+	'wlr-output-power-management-unstable-v1.xml',
 ]
 
 client_protos_src = []

--- a/protocols/wlr-output-power-management-unstable-v1.xml
+++ b/protocols/wlr-output-power-management-unstable-v1.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_output_power_management_unstable_v1">
+  <copyright>
+    Copyright © 2019 Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Control power management modes of outputs">
+    This protocol allows clients to control power management modes
+    of outputs that are currently part of the compositor space. The
+    intent is to allow special clients like desktop shells to power
+    down outputs when the system is idle.
+
+    To modify outputs not currently part of the compositor space see
+    wlr-output-management.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_output_power_manager_v1" version="1">
+    <description summary="manager to create per-output power management">
+      This interface is a manager that allows creating per-output power
+      management mode controls.
+    </description>
+
+    <request name="get_output_power">
+      <description summary="get a power management for an output">
+        Create a output power management mode control that can be used to
+        adjust the power management mode for a given output.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_power_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_power_v1" version="1">
+    <description summary="adjust power management mode for an output">
+      This object offers requests to set the power management mode of
+      an output.
+    </description>
+
+    <enum name="mode">
+      <entry name="off" value="0"
+             summary="Output is turned off."/>
+      <entry name="on" value="1"
+             summary="Output is turned on, no power saving"/>
+    </enum>
+
+    <enum name="error">
+      <entry name="invalid_mode" value="1" summary="inexistent power save mode"/>
+    </enum>
+
+    <request name="set_mode">
+      <description summary="Set an outputs power save mode">
+        Set an output's power save mode to the given mode. The mode change
+        is effective immediately. If the output does not support the given
+        mode a failed event is sent.
+      </description>
+      <arg name="mode" type="uint" enum="mode" summary="the power save mode to set"/>
+    </request>
+
+    <event name="mode">
+      <description summary="Report a power management mode change">
+        Report the power management mode change of an output.
+
+        The mode event is sent after an output changed its power
+        management mode. The reason can be a client using set_mode or the
+        compositor deciding to change an output's mode.
+        This event is also sent immediately when the object is created
+        so the client is informed about the current power management mode.
+      </description>
+      <arg name="mode" type="uint" enum="mode"
+           summary="the output's new power management mode"/>
+    </event>
+
+    <event name="failed">
+      <description summary="object no longer valid">
+        This event indicates that the output power management mode control
+        is no longer valid. This can happen for a number of reasons,
+        including:
+        - The output doesn't support power management
+        - Another client already has exclusive power management mode control
+          for this output
+        - The output disappeared
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this power management">
+        Destroys the output power management mode control object.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/src/main.c
+++ b/src/main.c
@@ -750,8 +750,10 @@ int wayvnc_start_capture_immediate(struct wayvnc* self)
 		return 0;
 
 	if (self->selected_output->power == OUTPUT_POWER_OFF) {
-		nvnc_log(NVNC_LOG_WARNING, "Output is in powersaving mode. Delaying capture until it turns on.");
-		// TODO: Attempt to turn it on?
+		nvnc_log(NVNC_LOG_WARNING, "Selected output is in powersaving mode. Delaying capture until it turns on.");
+		if (output_set_power_state(self->selected_output, OUTPUT_POWER_ON)
+				== 0)
+			nvnc_log(NVNC_LOG_WARNING, "Requested power ON.");
 		return 0;
 	}
 

--- a/src/output.c
+++ b/src/output.c
@@ -19,6 +19,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <errno.h>
+#include <assert.h>
 #include <wayland-client-protocol.h>
 #include <wayland-client.h>
 #include <neatvnc.h>
@@ -313,6 +315,21 @@ void output_set_wlr_output_power(struct output* self,
 
 	zwlr_output_power_v1_add_listener(self->wlr_output_power,
 			&wlr_output_power_listener, self);
+}
+
+int output_set_power_state(struct output* output, enum output_power_state state)
+{
+	assert(state != OUTPUT_POWER_UNKNOWN);
+	if (!output->wlr_output_power) {
+		errno = ENOENT;
+		return -1;
+	}
+	nvnc_log(NVNC_LOG_TRACE, "Output %s requesting power %s", output->name,
+			output_power_state_name(state));
+	int mode = (state == OUTPUT_POWER_ON) ? ZWLR_OUTPUT_POWER_V1_MODE_ON :
+		ZWLR_OUTPUT_POWER_V1_MODE_OFF;
+	zwlr_output_power_v1_set_mode(output->wlr_output_power, mode);
+	return 0;
 }
 
 struct output* output_find_by_id(struct wl_list* list, uint32_t id)


### PR DESCRIPTION
- Add DPMS state to the output object
- Don't attempt capture if an output is DPMS off
- Turn DPMS on when starting capture
- Blank the capture screen when DPMS is turned off

Fixes #114

I have read and understood CONTRIBUTING.md and its associated documents.