### PR TITLE
Custom option parser

### DIFF
--- a/include/option-parser.h
+++ b/include/option-parser.h
@@ -17,26 +17,40 @@
 #pragma once
 
 #include <stdio.h>
-#include <getopt.h>
+#include <stdbool.h>
 
 struct wv_option {
 	char short_opt;
 	const char* long_opt;
 	const char* schema;
 	const char* help;
+	const char* default_;
+	const char* positional;
+	bool is_subcommand;
+};
+
+struct wv_option_value {
+	const struct wv_option* option;
+	char value[256];
 };
 
 struct option_parser {
 	const struct wv_option* options;
-	char short_opts[128];
-	struct option long_opts[128];
 	int n_opts;
+
+	struct wv_option_value values[128];
+	int n_values;
+	int position;
+
+	int endpos;
 };
 
-#define OPTION_PARSER_CHECK_ALL_ARGUMENTS 0
-#define OPTION_PARSER_STOP_ON_FIRST_NONOPTION 1
-
-void option_parser_init(struct option_parser* self, const struct wv_option* options, unsigned flags);
+void option_parser_init(struct option_parser* self,
+		const struct wv_option* options);
 
 void option_parser_print_options(struct option_parser* self, FILE* stream);
-int option_parser_getopt(struct option_parser* self, int argc, char* argv[]);
+
+int option_parser_parse(struct option_parser* self, int argc,
+		const char* const* argv);
+const char* option_parser_get_value(const struct option_parser* self,
+		const char* name);

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ c_args = [
 	'-DAML_UNSTABLE_API=1',
 
 	'-Wno-unused-parameter',
+	'-Wno-missing-field-initializers',
 ]
 
 git = find_program('git', native: true, required: false)
@@ -196,4 +197,8 @@ if scdoc.found()
 			install_dir: '@0@/man1'.format(mandir)
 		)
 	endforeach
+endif
+
+if get_option('tests')
+	subdir('test')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,5 @@ option('man-pages', type: 'feature', value: 'auto',
 	description: 'Generate and install man pages')
 option('systemtap', type: 'boolean', value: false,
 	description: 'Enable tracing using sdt')
+option('tests', type: 'boolean', value: false,
+	description: 'Build unit tests')

--- a/src/main.c
+++ b/src/main.c
@@ -20,7 +20,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <unistd.h>
-#include <getopt.h>
 #include <assert.h>
 #include <inttypes.h>
 #include <errno.h>
@@ -1059,7 +1058,7 @@ static void on_nvnc_client_new(struct nvnc_client* client)
 			self->nr_clients);
 }
 
-void parse_keyboard_option(struct wayvnc* self, char* arg)
+void parse_keyboard_option(struct wayvnc* self, const char* arg)
 {
 	// Find optional variant, separated by -
 	char* index = strchr(arg, '-');
@@ -1242,6 +1241,7 @@ int main(int argc, char* argv[])
 	const char* output_name = NULL;
 	const char* seat_name = NULL;
 	const char* socket_path = NULL;
+	const char* keyboard_options = NULL;
 
 	bool overlay_cursor = false;
 	bool show_performance = false;
@@ -1253,6 +1253,8 @@ int main(int argc, char* argv[])
 	int log_level = NVNC_LOG_WARNING;
 
 	static const struct wv_option opts[] = {
+		{ .positional = "address" },
+		{ .positional = "port" },
 		{ 'C', "config", "<path>",
 		  "Select a config file." },
 		{ 'g', "gpu", NULL,
@@ -1268,7 +1270,8 @@ int main(int argc, char* argv[])
 		{ 'r', "render-cursor", NULL,
 		  "Enable overlay cursor rendering." },
 		{ 'f', "max-fps", "<fps>",
-		  "Set rate limit (default 30)." },
+		  "Set rate limit (default 30).",
+		  .default_ = "30" },
 		{ 'p', "performance", NULL,
 		  "Show performance counters." },
 		{ 'u', "unix-socket", NULL,
@@ -1280,84 +1283,53 @@ int main(int argc, char* argv[])
 		{ 'v', "verbose", NULL,
 		  "Be more verbose. Same as setting --log-level=info" },
 		{ 'L', "log-level", "<level>",
-		  "Set log level. The levels are: error, warning, info, debug trace and quiet." },
+		  "Set log level. The levels are: error, warning, info, debug trace and quiet.",
+		  .default_ = "warning" },
 		{ 'h', "help", NULL,
 		  "Get help (this text)." },
 		{ '\0', NULL, NULL, NULL }
 	};
 
 	struct option_parser option_parser;
-	option_parser_init(&option_parser, opts,
-			OPTION_PARSER_CHECK_ALL_ARGUMENTS);
+	option_parser_init(&option_parser, opts);
 
-	while (1) {
-		int c = option_parser_getopt(&option_parser, argc, argv);
-		if (c < 0)
-			break;
+	if (option_parser_parse(&option_parser, argc,
+				(const char* const*)argv) < 0)
+		return wayvnc_usage(&option_parser, stderr, 1);
 
-		switch (c) {
-		case 'C':
-			cfg_file = optarg;
-			break;
-		case 'g':
-			enable_gpu_features = true;
-			break;
-		case 'o':
-			output_name = optarg;
-			break;
-		case 'k':
-			parse_keyboard_option(&self, optarg);
-			break;
-		case 's':
-			seat_name = optarg;
-			break;
-		case 'S':
-			socket_path = optarg;
-			break;
-		case 'r':
-			overlay_cursor = true;
-			break;
-		case 'f':
-			max_rate = atoi(optarg);
-			break;
-		case 'p':
-			show_performance = true;
-			break;
-		case 'u':
-			use_unix_socket = true;
-			break;
-		case 'd':
-			disable_input = true;
-			break;
-		case 'v':
-			log_level = NVNC_LOG_INFO;
-			break;
-		case 'L':
-			log_level = log_level_from_string(optarg);
-			if (log_level < 0) {
-				fprintf(stderr, "Invalid log level: %s\n",
-						optarg);
-				return wayvnc_usage(&option_parser, stderr, 1);
-			}
-			break;
-		case 'V':
-			return show_version();
-		case 'h':
-			return wayvnc_usage(&option_parser, stdout, 0);
-		default:
-			return wayvnc_usage(&option_parser, stderr, 1);
-		}
+	if (option_parser_get_value(&option_parser, "version")) {
+		return show_version();
 	}
+
+	if (option_parser_get_value(&option_parser, "help")) {
+		return wayvnc_usage(&option_parser, stdout, 0);
+	}
+
+	cfg_file = option_parser_get_value(&option_parser, "config");
+	enable_gpu_features = !!option_parser_get_value(&option_parser, "gpu");
+	output_name = option_parser_get_value(&option_parser, "output");
+	seat_name = option_parser_get_value(&option_parser, "seat");
+	socket_path = option_parser_get_value(&option_parser, "socket");
+	overlay_cursor = !!option_parser_get_value(&option_parser, "render-cursor");
+	show_performance = !!option_parser_get_value(&option_parser, "performance");
+	use_unix_socket = !!option_parser_get_value(&option_parser, "unix");
+	disable_input = !!option_parser_get_value(&option_parser, "disable-input");
+	log_level = option_parser_get_value(&option_parser, "verbose")
+		? NVNC_LOG_INFO : NVNC_LOG_WARNING;
+	log_level = log_level_from_string(
+			option_parser_get_value(&option_parser, "log-level"));
+	max_rate = atoi(option_parser_get_value(&option_parser, "max-fps"));
+
+	keyboard_options = option_parser_get_value(&option_parser, "keyboard");
+	if (keyboard_options)
+		parse_keyboard_option(&self, keyboard_options);
 
 	nvnc_set_log_level(log_level);
 
-	int n_args = argc - optind;
-
-	if (n_args >= 1)
-		address = argv[optind];
-
-	if (n_args >= 2)
-		port = atoi(argv[optind + 1]);
+	address = option_parser_get_value(&option_parser, "address");
+	const char* port_str = option_parser_get_value(&option_parser, "port");
+	if (port_str)
+		port = atoi(port_str);
 
 	if (seat_name && disable_input) {
 		nvnc_log(NVNC_LOG_ERROR, "seat and disable-input are conflicting options");

--- a/test/option-parser-test.c
+++ b/test/option-parser-test.c
@@ -1,0 +1,214 @@
+#include "tst.h"
+
+#include "option-parser.h"
+
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+
+static const struct wv_option options[] = {
+	{ .positional = "first" },
+	{ .positional = "second" },
+	{ .positional = "third" },
+	{ .positional = "command", .is_subcommand = true },
+	{ 'a', "option-a", NULL, "Description of a" },
+	{ 'b', "option-b", NULL, "Description of b" },
+	{ 'v', "value-option", "value", "Description of v" },
+	{ },
+};
+
+static int test_simple(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+
+	const char* argv[] = {
+		"executable",
+		"-a",
+		"-b",
+		"pos 1",
+		"pos 2",
+	};
+
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+
+	ASSERT_STR_EQ("pos 1", option_parser_get_value(&parser, "first"));
+	ASSERT_STR_EQ("pos 2", option_parser_get_value(&parser, "second"));
+	ASSERT_FALSE(option_parser_get_value(&parser, "third"));
+	ASSERT_TRUE(option_parser_get_value(&parser, "a"));
+	ASSERT_TRUE(option_parser_get_value(&parser, "option-b"));
+	ASSERT_FALSE(option_parser_get_value(&parser, "value-option"));
+
+	return 0;
+}
+
+static int test_short_value_option_with_space(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "-v", "value" };
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+
+	ASSERT_STR_EQ("value", option_parser_get_value(&parser, "value-option"));
+	return 0;
+}
+
+static int test_short_value_option_without_space(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "-vvalue" };
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+
+	ASSERT_STR_EQ("value", option_parser_get_value(&parser, "value-option"));
+	return 0;
+}
+
+static int test_short_value_option_with_eq(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "-v=value" };
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+
+	ASSERT_STR_EQ("value", option_parser_get_value(&parser, "value-option"));
+	return 0;
+}
+
+static int test_long_value_option_with_space(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "--value-option", "value" };
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+
+	ASSERT_STR_EQ("value", option_parser_get_value(&parser, "value-option"));
+	return 0;
+}
+
+static int test_long_value_option_without_space(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "--value-option=value" };
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+
+	ASSERT_STR_EQ("value", option_parser_get_value(&parser, "value-option"));
+	return 0;
+}
+
+static int test_multi_short_option(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "-ab" };
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+
+	ASSERT_TRUE(option_parser_get_value(&parser, "a"));
+	ASSERT_TRUE(option_parser_get_value(&parser, "b"));
+	return 0;
+}
+
+static int test_multi_short_option_with_value(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "-abvthe-value" };
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+
+	ASSERT_TRUE(option_parser_get_value(&parser, "a"));
+	ASSERT_TRUE(option_parser_get_value(&parser, "b"));
+	ASSERT_STR_EQ("the-value", option_parser_get_value(&parser, "v"));
+	return 0;
+}
+
+static int test_stop(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "exec", "-a", "--", "-b"};
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+
+	ASSERT_TRUE(option_parser_get_value(&parser, "a"));
+	ASSERT_FALSE(option_parser_get_value(&parser, "b"));
+	return 0;
+}
+
+static int test_unknown_short_option(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "-x" };
+	ASSERT_INT_EQ(-1, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+	return 0;
+}
+
+static int test_unknown_long_option(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "--an-unknown-long-option" };
+	ASSERT_INT_EQ(-1, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+	return 0;
+}
+
+static int test_missing_short_value(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "-v" };
+	ASSERT_INT_EQ(-1, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+	return 0;
+}
+
+static int test_missing_long_value(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "--value-option" };
+	ASSERT_INT_EQ(-1, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+	return 0;
+}
+
+static int test_subcommand_without_arguments(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "-ab", "first", "second", "third",
+		"do-stuff" };
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+	ASSERT_INT_EQ(5, parser.endpos);
+	ASSERT_STR_EQ("do-stuff", option_parser_get_value(&parser, "command"));
+	return 0;
+}
+
+static int test_subcommand_with_arguments(void)
+{
+	struct option_parser parser;
+	option_parser_init(&parser, options);
+	const char* argv[] = { "executable", "-ab", "first", "second", "third",
+		"do-stuff", "--some-option", "another-argument"};
+	ASSERT_INT_EQ(0, option_parser_parse(&parser, ARRAY_SIZE(argv), argv));
+	ASSERT_INT_EQ(5, parser.endpos);
+	ASSERT_STR_EQ("do-stuff", option_parser_get_value(&parser, "command"));
+	return 0;
+}
+
+int main()
+{
+	int r = 0;
+	RUN_TEST(test_simple);
+	RUN_TEST(test_short_value_option_with_space);
+	RUN_TEST(test_short_value_option_without_space);
+	RUN_TEST(test_short_value_option_with_eq);
+	RUN_TEST(test_long_value_option_with_space);
+	RUN_TEST(test_long_value_option_without_space);
+	RUN_TEST(test_multi_short_option);
+	RUN_TEST(test_multi_short_option_with_value);
+	RUN_TEST(test_stop);
+	RUN_TEST(test_unknown_short_option);
+	RUN_TEST(test_unknown_long_option);
+	RUN_TEST(test_missing_short_value);
+	RUN_TEST(test_missing_long_value);
+	RUN_TEST(test_subcommand_without_arguments);
+	RUN_TEST(test_subcommand_with_arguments);
+	return r;
+}


### PR DESCRIPTION
This implements a custom option parser.
The individual commit history is not great, but I've kept it for the sake of review. The commits will be squashed before merging for the sake of bisectability.

The new parser allows us to define positional options and subcommands in the "option schema". This helps with consistency and facilitates abstractions.