### PR TITLE
Remove the help command from wayvncctl

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,47 +159,6 @@ the running wayvnc instance.
 Use the `wayvncctl` utility to interact with this control socket from the
 command line.
 
-The `help` command can interactively query the available IPC commands:
-
-```
-$ wayvncctl help
-Commands:
-    - help
-    - version
-    - event-receive
-    - set-output
-    - get-clients
-    - get-outputs
-    - disconnect-client
-    - wayvnc-exit
-
-Run 'wayvncctl command-name --help' for command-specific details.
-
-Events:
-    - client-connected
-    - client-disconnected
-    - capture-changed
-
-Run 'wayvncctl help --event=event-name' for event-specific details.
-```
-
-And give descriptions and usage for specific commands:
-```
-$ wayvncctl set-output --help
-Usage: wayvncctl [options] set-output [params]
-
-Switch the actively captured output
-
-Parameters:
-  --switch-to=...
-    The specific output name to capture
-
-  --cycle=...
-    Either "next" or "prev"
-
-Run 'wayvncctl --help' for allowed options
-```
-
 See the `wayvnc(1)` manpage for an in-depth description of the IPC protocol and
 the available commands, and `wayvncctl(1)` for more on the command line
 interface.

--- a/include/table-printer.h
+++ b/include/table-printer.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2023 Jim Ramsay
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include <stdio.h>
+
+struct table_printer{
+	FILE* stream;
+	int max_width;
+	int left_indent;
+	int left_width;
+	int column_offset;
+};
+
+// Sets default values for every subsequent table_printer_new (Optional: defaults to 80/4/8)
+void table_printer_set_defaults(int max_width, int left_indent,
+		int column_offset);
+
+void table_printer_init(struct table_printer* self, FILE* stream,
+		int left_width);
+
+void table_printer_print_line(struct table_printer* self, const char* left_text,
+		const char* right_text);
+
+void table_printer_print_fmtline(struct table_printer* self,
+		const char* right_text,
+		const char* left_format, ...);
+
+int table_printer_reflow_text(char* dst, int dst_size, const char* src,
+		int width);
+
+void table_printer_indent_and_reflow_text(FILE* stream, const char* src,
+		int width, int first_line_indent, int subsequent_indent);
+

--- a/meson.build
+++ b/meson.build
@@ -99,6 +99,7 @@ sources = [
 	'src/ctl-server.c',
 	'src/ctl-commands.c',
 	'src/option-parser.c',
+        'src/table-printer.c',
 ]
 
 dependencies = [
@@ -123,6 +124,7 @@ ctlsources = [
 	'src/ctl-commands.c',
 	'src/strlcpy.c',
 	'src/option-parser.c',
+        'src/table-printer.c',
 ]
 
 ctldependencies = [

--- a/src/ctl-commands.c
+++ b/src/ctl-commands.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Jim Ramsay
+ * Copyright (c) 2022-2023 Jim Ramsay
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -75,15 +75,15 @@ struct cmd_info ctl_command_list[] = {
 
 struct cmd_info ctl_event_list[] = {
 	[EVT_CLIENT_CONNECTED] = {"client-connected",
-		"Sent when a new vnc client connects to wayvnc",
+		"Sent by wayvnc when a new vnc client connects",
 		{ CLIENT_EVENT_PARAMS("including") }
 	},
 	[EVT_CLIENT_DISCONNECTED] = {"client-disconnected",
-		"Sent when a vnc client disconnects from wayvnc",
+		"Sent by waynvc when a vnc client disconnects",
 		{ CLIENT_EVENT_PARAMS("not including") }
 	},
 	[EVT_CAPTURE_CHANGED] = {"capture-changed",
-		"Sent when wayvnc changes which output is captured",
+		"Sent by wayvnc when the catured output is changed",
 		{
 			{"output", "The name of the output now being captured"},
 			{NULL, NULL},

--- a/src/table-printer.c
+++ b/src/table-printer.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2023 Andri Yngvason
+ * Copyright (c) 2023 Jim Ramsay
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ * INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ * LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ * PERFORMANCE OF THIS SOFTWARE.
+ */
+
+#include "table-printer.h"
+
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <string.h>
+#include <assert.h>
+
+static struct table_printer defaults = {
+	.max_width = 80,
+	.left_indent = 4,
+	.column_offset = 8,
+	.stream = NULL,
+	.left_width = 0,
+};
+
+void table_printer_set_defaults(int max_width, int left_indent,
+		int column_offset)
+{
+	defaults.max_width = max_width;
+	defaults.left_indent = left_indent;
+	defaults.column_offset = column_offset;
+}
+
+void table_printer_init(struct table_printer* self, FILE* stream,
+		int left_width)
+{
+	memcpy(self, &defaults, sizeof(*self));
+	self->stream = stream;
+	self->left_width = left_width;
+}
+
+int table_printer_reflow_text(char* dst, int dst_size, const char* src,
+		int width)
+{
+	int line_len = 0;
+	int last_space_pos = 0;
+
+	int dst_len = 0;
+	int i = 0;
+
+	while (true) {
+		char c = src[i];
+		if (line_len > width) {
+			// first word > width
+			assert(last_space_pos > 0);
+			// subsequent word > width
+			assert(dst[last_space_pos] != '\n');
+
+			dst_len -= i - last_space_pos;
+			dst[dst_len++] = '\n';
+			i = last_space_pos + 1;
+			line_len = 0;
+			continue;
+		}
+		if (!c)
+			break;
+
+		if (c == ' ')
+			last_space_pos = i;
+		dst[dst_len++] = c;
+		assert(dst_len < dst_size);
+		++line_len;
+		++i;
+	}
+
+	dst[dst_len] = '\0';
+	return dst_len;
+}
+
+void table_printer_indent_and_reflow_text(FILE* stream, const char* src,
+		int width, int first_line_indent, int subsequent_indent)
+{
+	char buffer[256];
+	table_printer_reflow_text(buffer, sizeof(buffer), src, width);
+
+	char* line = strtok(buffer, "\n");
+	fprintf(stream, "%*s%s\n", first_line_indent, "", line);
+
+	while (true) {
+		line = strtok(NULL, "\n");
+		if (!line)
+			break;
+
+		fprintf(stream, "%*s%s\n", subsequent_indent, "", line);
+	}
+}
+
+void table_printer_print_line(struct table_printer* self, const char* left_text,
+		const char* right_text)
+{
+	fprintf(self->stream, "%*s", self->left_indent, "");
+	int field_len = fprintf(self->stream, "%s", left_text);
+	fprintf(self->stream, "%*s", self->left_width - field_len + self->column_offset, "");
+	int column_indent = self->left_indent + self->left_width + self->column_offset;
+	int column_width = self->max_width - column_indent;
+	table_printer_indent_and_reflow_text(self->stream,
+			right_text,
+			column_width, 0, column_indent);
+}
+
+void table_printer_print_fmtline(struct table_printer* self,
+		const char* right_text,
+		const char* left_format, ...)
+{
+	char buf[64];
+	va_list args;
+	va_start(args, left_format);
+	vsnprintf(buf, sizeof(buf), left_format, args);
+	va_end(args);
+	table_printer_print_line(self, buf, right_text);
+}
+

--- a/src/wayvncctl.c
+++ b/src/wayvncctl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Jim Ramsay
+ * Copyright (c) 2022-2023 Jim Ramsay
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -44,7 +44,7 @@ struct wayvncctl {
 static int wayvncctl_usage(FILE* stream, struct option_parser* options, int rc)
 {
 	static const char* usage =
-"Usage: wayvncctl [options] [command [--param1=value1 ...]]\n"
+"Usage: wayvncctl [options] <command> [parameters]\n"
 "\n"
 "Connects to and interacts with a running wayvnc instance.";
 	fprintf(stream, "%s\n\n", usage);
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
 
 	// No command; nothing to do...
 	if (!option_parser_get_value(&option_parser, "command"))
-		return 0;
+		return wayvncctl_usage(stdout, &option_parser, 1);
 
 	ctl_client_debug_log(verbose);
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,10 +1,18 @@
-option_parser = executable('option-parser',
+test('table-printer', executable('table-printer',
+	[
+		'table-printer-test.c',
+		'../src/table-printer.c',
+	],
+	include_directories: inc,
+	dependencies: [ ],
+))
+test('option-parser', executable('option-parser',
 	[
 		'option-parser-test.c',
 		'../src/option-parser.c',
+		'../src/table-printer.c',
 		'../src/strlcpy.c',
 	],
 	include_directories: inc,
 	dependencies: [ ],
-)
-test('option-parser', option_parser)
+))

--- a/test/table-printer-test.c
+++ b/test/table-printer-test.c
@@ -1,0 +1,145 @@
+#include "tst.h"
+#include "table-printer.h"
+#include <stdlib.h>
+
+static int test_reflow_text(void)
+{
+	char buf[20];
+	const char* src = "one two three four";
+	int len;
+
+	len = table_printer_reflow_text(buf, sizeof(buf), src, 20);
+	ASSERT_INT_EQ(18, len);
+	ASSERT_STR_EQ("one two three four", buf);
+
+	len = table_printer_reflow_text(buf, sizeof(buf), src, 18);
+	ASSERT_INT_EQ(18, len);
+	ASSERT_STR_EQ("one two three four", buf);
+
+	len = table_printer_reflow_text(buf, sizeof(buf), src, 17);
+	ASSERT_INT_EQ(18, len);
+	ASSERT_STR_EQ("one two three\nfour", buf);
+
+	len = table_printer_reflow_text(buf, sizeof(buf), src, 10);
+	ASSERT_INT_EQ(18, len);
+	ASSERT_STR_EQ("one two\nthree four", buf);
+
+	len = table_printer_reflow_text(buf, sizeof(buf), src, 8);
+	ASSERT_INT_EQ(18, len);
+	ASSERT_STR_EQ("one two\nthree\nfour", buf);
+
+	len = table_printer_reflow_text(buf, sizeof(buf), src, 7);
+	ASSERT_INT_EQ(18, len);
+	ASSERT_STR_EQ("one two\nthree\nfour", buf);
+
+	len = table_printer_reflow_text(buf, sizeof(buf), src, 6);
+	ASSERT_INT_EQ(18, len);
+	ASSERT_STR_EQ("one\ntwo\nthree\nfour", buf);
+
+	len = table_printer_reflow_text(buf, sizeof(buf), src, 5);
+	ASSERT_INT_EQ(18, len);
+	ASSERT_STR_EQ("one\ntwo\nthree\nfour", buf);
+
+	// width <= 4 cause aborts (if any word length > width)
+
+	return 0;
+}
+
+static int test_indent_and_reflow(void)
+{
+	size_t len;
+	char* buf;
+	FILE* stream;
+
+	stream = open_memstream(&buf, &len);
+	table_printer_indent_and_reflow_text(stream, "one two three four", 7, 2, 4);
+	fclose(stream);
+	// strlen(src)=18 + first=2 + subsequent=(2x4) + newline=1
+	ASSERT_INT_EQ(29, len);
+	ASSERT_STR_EQ("  one two\n    three\n    four\n", buf);
+	free(buf);
+	return 0;
+}
+
+static int test_defaults(void)
+{
+	struct table_printer one;
+	table_printer_init(&one, stdout, 1);
+	table_printer_set_defaults(20, 2, 2);
+	struct table_printer two;
+	table_printer_init(&two, stderr, 2);
+	ASSERT_INT_EQ(80, one.max_width);
+	ASSERT_INT_EQ(4, one.left_indent);
+	ASSERT_INT_EQ(8, one.column_offset);
+	ASSERT_INT_EQ(1, one.left_width);
+	ASSERT_PTR_EQ(stdout, one.stream);
+	ASSERT_INT_EQ(20, two.max_width);
+	ASSERT_INT_EQ(2, two.left_indent);
+	ASSERT_INT_EQ(2, two.column_offset);
+	ASSERT_INT_EQ(2, two.left_width);
+	ASSERT_PTR_EQ(stderr, two.stream);
+	return 0;
+}
+
+static int test_print_line(void)
+{
+	size_t len;
+	char* buf;
+	struct table_printer printer = {
+		.max_width = 20,
+		.left_indent = 2,
+		.left_width = 6,
+		.column_offset = 2,
+	};
+
+	printer.stream = open_memstream(&buf, &len);
+	table_printer_print_line(&printer, "left", "right");
+	fclose(printer.stream);
+	ASSERT_STR_EQ("  left    right\n", buf);
+	free(buf);
+
+	printer.stream = open_memstream(&buf, &len);
+	table_printer_print_line(&printer, "left", "right side will wrap");
+	fclose(printer.stream);
+	ASSERT_STR_EQ("  left    right side\n"
+		      "          will wrap\n", buf);
+	free(buf);
+	return 0;
+}
+
+static int test_print_fmtline(void)
+{
+	size_t len;
+	char* buf;
+	struct table_printer printer = {
+		.max_width = 20,
+		.left_indent = 2,
+		.left_width = 6,
+		.column_offset = 2,
+	};
+
+	printer.stream = open_memstream(&buf, &len);
+	table_printer_print_fmtline(&printer, "right", "left");
+	fclose(printer.stream);
+	ASSERT_STR_EQ("  left    right\n", buf);
+	free(buf);
+
+	printer.stream = open_memstream(&buf, &len);
+	table_printer_print_fmtline(&printer, "right side will wrap", "left%d", 2);
+	fclose(printer.stream);
+	ASSERT_STR_EQ("  left2   right side\n"
+		      "          will wrap\n", buf);
+	free(buf);
+	return 0;
+}
+
+int main()
+{
+	int r = 0;
+	RUN_TEST(test_reflow_text);
+	RUN_TEST(test_indent_and_reflow);
+	RUN_TEST(test_defaults);
+	RUN_TEST(test_print_line);
+	RUN_TEST(test_print_fmtline);
+	return r;
+}

--- a/wayvncctl.scd
+++ b/wayvncctl.scd
@@ -40,17 +40,15 @@ wayvncctl - A command line control client for wayvnc(1)
 *wayvnc(1)* allows runtime interaction via a unix socket json-ipc mechanism.
 This command line utility provides easy interaction with those commands.
 
-For a full list of currently supported commands, see
-*wayvnc(1)* section _IPC COMMANDS_, or run the
-*wayvncctl help* command.
+This command is largely self-documenting:
 
-Running *wayvncctl help* returns a list of the available commands and events.
-
-Running *wayvncctl command-name --help* returns a description of the server-side
-command and its available parameters.
-
-Running *wayvncctl help --event=event-name* returns a description of the
-server-side event and expected parameters.
+- Running *wayvncctl --help* lists all supported IPC commands.
+- Running *wayvncctl command-name --help* returns a description of the given
+  command and its available parameters.
+- Running *wayvncctl event-receive --help* includes a list of all supported event
+  names.
+- Running *wayvncctl event-receive --show=event-name* returns a
+  description of the given event and expected data fields.
 
 # ASYNCHRONOUS EVENTS
 
@@ -107,46 +105,12 @@ generate 2 additional events not documented in *wayvnc(1)*:
 
 # EXAMPLES
 
-Query the server for all available IPC command names:
-
-```
-$ wayvncctl help
-Commands:
-    - help
-    - version
-    - event-receive
-    - set-output
-    - get-clients
-    - get-outputs
-    - disconnect-client
-    - wayvnc-exit
-
-Run 'wayvncctl command-name --help' for command-specific details.
-
-Events:
-    - client-connected
-    - client-disconnected
-    - capture-changed
-
-Run 'wayvncctl help --event=event-name' for event-specific details.
-```
-
 Get help on the "set-output" IPC command:
 
 ```
 $ wayvncctl set-output --help
 Usage: wayvncctl [options] set-output [params]
-
-Switch the actively captured output
-
-Parameters:
-  --switch-to=...
-    The specific output name to capture
-
-  --cycle=...
-    Either "next" or "prev"
-
-Run 'wayvncctl --help' for allowed options
+...
 ```
 
 Cycle to the next active output:


### PR DESCRIPTION
- Remove 'help' command and clean up help output
- Add help text for wayvncctl-only events
- Refactor option-parser table printing code for reuse
- Add command and event details to help output

Fixes #213
