### PR TITLE
Rename and reorder all wayvncctl commands

### DIFF
--- a/examples/single-output-sway
+++ b/examples/single-output-sway
@@ -14,7 +14,7 @@ fi
 
 find_output_matching() {
     local pattern=$1
-    $WAYVNCCTL -j get-outputs | jq -r ".[].name | match(\"$pattern\").string"
+    $WAYVNCCTL -j output-list | jq -r ".[].name | match(\"$pattern\").string"
 }
 
 wait_for_output_matching() {
@@ -41,7 +41,7 @@ restore_outputs() {
         local firstOutput=${OUTPUTS_TO_RECONNECT[0]}
         echo "Switching wayvnc back to physical output $firstOutput"
         wait_for_output_matching "$firstOutput" >/dev/null
-        $WAYVNCCTL set-output --switch-to="$firstOutput"
+        $WAYVNCCTL output-set --switch-to="$firstOutput"
         echo "Removing virtual output $HEADLESS"
         $SWAYMSG output "$HEADLESS" unplug
     fi
@@ -55,17 +55,17 @@ collapse_outputs() {
         local preexisting="$(find_output_matching 'HEADLESS-\\d+')"
         if [[ $preexisting ]]; then
             echo "Switching to preexisting virtual output $preexisting"
-            $WAYVNCCTL set-output --switch-to="$preexisting"
+            $WAYVNCCTL output-set --switch-to="$preexisting"
         else
             echo "Creating a virtual display"
             $SWAYMSG create_output
             echo "Waiting for virtusl output to be created..."
             HEADLESS=$(wait_for_output_matching 'HEADLESS-\\d+')
             echo "Switching to virtual output $HEADLESS"
-            $WAYVNCCTL set-output --switch-to="$HEADLESS"
+            $WAYVNCCTL output-set --switch-to="$HEADLESS"
         fi
     fi
-    for output in $($WAYVNCCTL -j get-outputs | jq -r '.[] | select(.captured==false).name'); do
+    for output in $($WAYVNCCTL -j output-list | jq -r '.[] | select(.captured==false).name'); do
         echo "Disabling extra output $output"
         $SWAYMSG output "$output" disable
         OUTPUTS_TO_RECONNECT+=("$output")

--- a/include/ctl-commands.h
+++ b/include/ctl-commands.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Jim Ramsay
+ * Copyright (c) 2022-2023 Jim Ramsay
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -18,21 +18,21 @@
 
 enum cmd_type {
 	CMD_HELP,
-	CMD_VERSION,
 	CMD_EVENT_RECEIVE,
-	CMD_SET_OUTPUT,
-	CMD_GET_CLIENTS,
-	CMD_GET_OUTPUTS,
-	CMD_DISCONNECT_CLIENT,
+	CMD_CLIENT_LIST,
+	CMD_CLIENT_DISCONNECT,
+	CMD_OUTPUT_LIST,
+	CMD_OUTPUT_SET,
+	CMD_VERSION,
 	CMD_WAYVNC_EXIT,
 	CMD_UNKNOWN,
 };
 #define CMD_LIST_LEN CMD_UNKNOWN
 
 enum event_type {
+	EVT_CAPTURE_CHANGED,
 	EVT_CLIENT_CONNECTED,
 	EVT_CLIENT_DISCONNECTED,
-	EVT_CAPTURE_CHANGED,
 	EVT_UNKNOWN,
 };
 #define EVT_LIST_LEN EVT_UNKNOWN

--- a/src/ctl-client.c
+++ b/src/ctl-client.c
@@ -374,14 +374,14 @@ static void pretty_print(json_t* data,
 	case CMD_VERSION:
 		pretty_version(data);
 		break;
-	case CMD_GET_CLIENTS:
+	case CMD_CLIENT_LIST:
 		pretty_client_list(data);
 		break;
-	case CMD_GET_OUTPUTS:
+	case CMD_OUTPUT_LIST:
 		pretty_output_list(data);
 		break;
-	case CMD_DISCONNECT_CLIENT:
-	case CMD_SET_OUTPUT:
+	case CMD_CLIENT_DISCONNECT:
+	case CMD_OUTPUT_SET:
 	case CMD_WAYVNC_EXIT:
 		printf("Ok\n");
 		break;

--- a/src/ctl-commands.c
+++ b/src/ctl-commands.c
@@ -37,26 +37,26 @@ struct cmd_info ctl_command_list[] = {
 		// TODO: Event type filtering?
 		{{NULL, NULL}}
 	},
-	[CMD_SET_OUTPUT] = { "set-output",
+	[CMD_CLIENT_LIST] = { "client-list",
+		"Return a list of all currently connected VNC sessions",
+		{{NULL, NULL}}
+	},
+	[CMD_CLIENT_DISCONNECT] = { "client-disconnect",
+		"Disconnect a VNC session",
+		{
+			{"id", "The ID of the client to disconnect"},
+			{NULL, NULL},
+		}
+	},
+	[CMD_OUTPUT_LIST] = { "output-list",
+		"Return a list of all currently detected Wayland outputs",
+		{{NULL, NULL}}
+	},
+	[CMD_OUTPUT_SET] = { "output-set",
 		"Switch the actively captured output",
 		{
 			{"switch-to", "The specific output name to capture"},
 			{"cycle", "Either \"next\" or \"prev\""},
-			{NULL, NULL},
-		}
-	},
-	[CMD_GET_CLIENTS] = { "get-clients",
-		"Return a list of all currently connected  VNC sessions",
-		{{NULL, NULL}}
-	},
-	[CMD_GET_OUTPUTS] = { "get-outputs",
-		"Return a list of all currently detected Wayland outputs",
-		{{NULL, NULL}}
-	},
-	[CMD_DISCONNECT_CLIENT] = { "disconnect-client",
-		"Disconnect a VNC session",
-		{
-			{"id", "The ID of the client to disconnect"},
 			{NULL, NULL},
 		}
 	},
@@ -74,6 +74,13 @@ struct cmd_info ctl_command_list[] = {
 	{NULL, NULL},
 
 struct cmd_info ctl_event_list[] = {
+	[EVT_CAPTURE_CHANGED] = {"capture-changed",
+		"Sent by wayvnc when the catured output is changed",
+		{
+			{"output", "The name of the output now being captured"},
+			{NULL, NULL},
+		},
+	},
 	[EVT_CLIENT_CONNECTED] = {"client-connected",
 		"Sent by wayvnc when a new vnc client connects",
 		{ CLIENT_EVENT_PARAMS("including") }
@@ -82,14 +89,6 @@ struct cmd_info ctl_event_list[] = {
 		"Sent by waynvc when a vnc client disconnects",
 		{ CLIENT_EVENT_PARAMS("not including") }
 	},
-	[EVT_CAPTURE_CHANGED] = {"capture-changed",
-		"Sent by wayvnc when the catured output is changed",
-		{
-			{"output", "The name of the output now being captured"},
-			{NULL, NULL},
-		},
-	},
-
 };
 
 enum cmd_type ctl_command_parse_name(const char* name)

--- a/src/ctl-server.c
+++ b/src/ctl-server.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Jim Ramsay
+ * Copyright (c) 2022-2023 Jim Ramsay
  *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -212,16 +212,16 @@ static struct cmd* parse_command(struct jsonipc_request* ipc,
 	case CMD_HELP:
 		cmd = (struct cmd*)cmd_help_new(ipc->params, err);
 		break;
-	case CMD_SET_OUTPUT:
+	case CMD_OUTPUT_SET:
 		cmd = (struct cmd*)cmd_set_output_new(ipc->params, err);
 		break;
-	case CMD_DISCONNECT_CLIENT:
+	case CMD_CLIENT_DISCONNECT:
 		cmd = (struct cmd*)cmd_disconnect_client_new(ipc->params, err);
 		break;
 	case CMD_VERSION:
 	case CMD_EVENT_RECEIVE:
-	case CMD_GET_CLIENTS:
-	case CMD_GET_OUTPUTS:
+	case CMD_CLIENT_LIST:
+	case CMD_OUTPUT_LIST:
 	case CMD_WAYVNC_EXIT:
 		cmd = calloc(1, sizeof(*cmd));
 		break;
@@ -404,7 +404,7 @@ static struct cmd_response* ctl_server_dispatch_cmd(struct ctl* self,
 		response = generate_help_object(c->id, c->id_is_command);
 		break;
 		}
-	case CMD_SET_OUTPUT: {
+	case CMD_OUTPUT_SET: {
 		struct cmd_set_output* c = (struct cmd_set_output*)cmd;
 		if (c->target[0] != '\0')
 			response = self->actions.on_output_switch(self, c->target);
@@ -412,7 +412,7 @@ static struct cmd_response* ctl_server_dispatch_cmd(struct ctl* self,
 			response = self->actions.on_output_cycle(self, c->cycle);
 		break;
 		}
-	case CMD_DISCONNECT_CLIENT: {
+	case CMD_CLIENT_DISCONNECT: {
 		struct cmd_disconnect_client* c =
 			(struct cmd_disconnect_client*)cmd;
 		response = self->actions.on_disconnect_client(self, c->id);
@@ -428,10 +428,10 @@ static struct cmd_response* ctl_server_dispatch_cmd(struct ctl* self,
 		client->accept_events = true;
 		response = cmd_ok();
 		break;
-	case CMD_GET_CLIENTS:
+	case CMD_CLIENT_LIST:
 		response = generate_vnc_client_list(self);
 		break;
-	case CMD_GET_OUTPUTS:
+	case CMD_OUTPUT_LIST:
 		response = generate_output_list(self);
 		break;
 	case CMD_UNKNOWN:

--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -72,11 +72,11 @@ If the Wayland session consists of multiple outputs, only one will be captured.
 By default this will be the first one, but can be specified by the _-o_ command
 line argument. The argument accepts the short name such as _eDP-1_ or _DP-4_.
 Running wayvnc in verbose mode (_-v_) will display the names of all outputs on
-startup, or you can query them at runtime via the *wayvncctl get-outputs*
+startup, or you can query them at runtime via the *wayvncctl output-list*
 command.
 
 You can also change which output is being captured on the fly via the *wayvncctl
-set-output* command.
+output-set* command.
 
 # CONFIGURATION
 
@@ -173,13 +173,6 @@ available commands.
 If an optional *command* parameter refers to one of those commands by name, the
 response data will be a detailed description of that command and its parameters.
 
-_VERSION_
-
-The *version* command queries the running wayvnc instance for its version
-information. Much like the _-V_ option, the response data will contain the
-version numbers of wayvnc, as well as the versions of the neatvnc and aml
-components.
-
 _EVENT-RECEIVE_
 
 The *event-receive* command registers for asynchronous server events. See the
@@ -190,11 +183,31 @@ Event registration registers for all available server events and is scoped to
 the current connection only. If a client disconnects and reconnects, it must
 re-register for events.
 
-_SET-OUTPUT_
+_CLIENT-LIST_
 
-For multi-output wayland displays, this command switches which output is
-actively captured by wayvnc. This operates in 2 different modes, depending on
-which parameters are supplied:
+The *client-list* command retrieves a list of all VNC clients currently
+connected to wayvnc.
+
+_CLIENT-DISCONNECT_
+
+The *client-disconnect* command disconnects a single VNC client.
+
+Parameters:
+
+*id*
+	Required: The ID of the client to disconnect.  This ID can be found from the
+	_GET-CLIENTS_ command or receipt of a _CLIENT-CONNECTED_ event.
+
+_OUTPUT-LIST_
+
+The *output-list* command retrieves a list of all outputs known to wayvnc and
+whether or not each one is currently being captured.
+
+_OUTPUT-SET_
+
+For multi-output wayland displays, the *output-set* command switches which
+output is actively captured by wayvnc. This operates in 2 different modes,
+depending on which one of these parameters is supplied:
 
 *cycle=next|prev*
 	Cycle to the next/prev output in the output list, wrapping back to the
@@ -203,31 +216,28 @@ which parameters are supplied:
 *switch-to=output-name*
 	Switch to a specific output by name.
 
-_DISCONNECT_CLIENT_
+_VERSION_
 
-The *disconnect-client* command disconnects a single VNC client.
+The *version* command queries the running wayvnc instance for its version
+information. Much like the _-V_ option, the response data will contain the
+version numbers of wayvnc, as well as the versions of the neatvnc and aml
+components.
 
-Parameters:
-
-*id*
-	Required: The ID of the client to disconnect.  This ID can be found from the
-	_GET-CLIENTS_ command or receipt of a _CLIENT-CONNECTED_ event.
-
-_WAYVNC_EXIT_
+_WAYVNC-EXIT_
 
 The *wayvnc-exit* command disconnects all clients and shuts down wayvnc.
 
-_GET-CLIENTS_
-
-The *get-clients* command retrieves a list of all VNC clients currently
-connected to wayvnc.
-
-_GET-OUTPUTS_
-
-The *get-outputs* command retrieves a list of all outputs known to wayvnc and
-whether or not each one is currently being captured.
-
 ## IPC EVENTS
+
+_CAPTURE_CHANGED_
+
+The *capture-changed* event is sent when the currently captured output
+changes.
+
+Parameters:
+
+*output=...*
+	The name of the output now being captured.
 
 _CLIENT-CONNECTED_
 
@@ -265,16 +275,6 @@ Parameters:
 
 *username=...*
 	The username used to authenticate this client. May be null.
-
-_CAPTURE_CHANGED_
-
-The *capture-changed* event is sent when the currently captured output
-changes.
-
-Parameters:
-
-*output=...*
-	The name of the output now being captured.
 
 ## IPC MESSAGE FORMAT
 

--- a/wayvncctl.scd
+++ b/wayvncctl.scd
@@ -105,18 +105,18 @@ generate 2 additional events not documented in *wayvnc(1)*:
 
 # EXAMPLES
 
-Get help on the "set-output" IPC command:
+Get help on the "output-set" IPC command:
 
 ```
-$ wayvncctl set-output --help
-Usage: wayvncctl [options] set-output [params]
+$ wayvncctl output-set --help
+Usage: wayvncctl [options] output-set [params]
 ...
 ```
 
 Cycle to the next active output:
 
 ```
-$ wayvncctl set-output --cycle=next
+$ wayvncctl output-set --cycle=next
 ```
 
 Get json-formatted version information:


### PR DESCRIPTION
This introduces a better hierarchical naming convention for IPC commands.

Fixes #217