### PR TITLE
Fix all non-parameterized IPCs

### DIFF
--- a/src/ctl-server.c
+++ b/src/ctl-server.c
@@ -200,6 +200,7 @@ static struct cmd* parse_command(struct jsonipc_request* ipc,
 	case CMD_OUTPUT_LIST:
 	case CMD_OUTPUT_CYCLE:
 	case CMD_WAYVNC_EXIT:
+		cmd = calloc(1, sizeof(*cmd));
 		break;
 	case CMD_UNKNOWN:
 		jsonipc_error_set_new(err, ENOENT,


### PR DESCRIPTION
Reverts part of 0b970ba3 which disabled all IPCs that don't take
parameters.

Signed-off-by: Jim Ramsay <i.am@jimramsay.com>
