### PR TITLE
Dont include ctrl-server.h in client file

### DIFF
--- a/src/ctl-client.c
+++ b/src/ctl-client.c
@@ -30,7 +30,6 @@
 #include "json-ipc.h"
 #include "ctl-client.h"
 #include "ctl-commands.h"
-#include "ctl-server.h"
 #include "strlcpy.h"
 #include "util.h"
 #include "option-parser.h"


### PR DESCRIPTION
Seems to be a copy/paste mistake.
I don't see that any of the definitions of that header are used in `ctl-client.c`.

Fix https://github.com/any1/wayvnc/issues/232