### PR TITLE
Fix 'wayvncctl wayvnc-exit' return code

### DIFF
--- a/src/ctl-client.c
+++ b/src/ctl-client.c
@@ -671,12 +671,16 @@ static int ctl_client_event_loop(struct ctl_client* self,
 }
 
 static int ctl_client_print_single_command(struct ctl_client* self,
-		struct jsonipc_request* request)
+		enum cmd_type cmd, struct jsonipc_request* request)
 {
 	struct jsonipc_response* response = ctl_client_run_single_command(self,
 			request);
-	if (!response)
+	if (!response) {
+		if (errno == ECONNRESET && cmd == CMD_WAYVNC_EXIT)
+			return 0;
+
 		return 1;
+	}
 
 	int result = ctl_client_print_response(self, request, response);
 	jsonipc_response_destroy(response);
@@ -908,7 +912,7 @@ int ctl_client_run_command(struct ctl_client* self,
 		result = ctl_client_event_loop(self, request);
 		break;
 	default:
-		result = ctl_client_print_single_command(self, request);
+		result = ctl_client_print_single_command(self, cmd, request);
 		break;
 	}
 

--- a/test/integration/integration.sh
+++ b/test/integration/integration.sh
@@ -239,9 +239,7 @@ test_output_list_ipc() {
 
 test_exit_ipc() {
 	echo "Checking wayvnc-exit command"
-	# Ignore errors because killing the socket races vs receiving
-	# a return message: https://github.com/any1/wayvnc/issues/233
-	$WAYVNCCTL wayvnc-exit &>/dev/null || true
+	$WAYVNCCTL wayvnc-exit &>/dev/null
 	wait_while kill -0 $WAYVNC_PID >/dev/null
 	echo "  wayvnc is shutdown"
 	unset WAYVNC_PID


### PR DESCRIPTION
When shutting down wayvnc, it is likely the IPC connection will drop
before the IPC response ia received, so count dicsonnection as success.

Fixes #233

I have read and understood CONTRIBUTING.md and its associated documents.
