### PR TITLE
Adding instructions to install on gentoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ zypper install wayvnc
 
 # Void Linux
 xbps-install wayvnc
+
+# Gentoo
+emerge gui-apps/wayvnc
 ```
 
 ## Building


### PR DESCRIPTION
It's a really simple pull request, since wayvnc is in gentoo's repository I thought it was a good idea to include it to README.md