### PR TITLE
main: Added quit on last client disconnect

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1726,7 +1726,6 @@ int main(int argc, char* argv[])
 	bool use_transient_seat = false;
 
 	bool quit_on_disconnect = false;
-	bool first_client_connected = false;
 
 	int drm_fd MAYBE_UNUSED = -1;
 

--- a/src/main.c
+++ b/src/main.c
@@ -84,7 +84,7 @@ enum socket_type {
 
 struct wayvnc {
 	bool do_exit;
-	bool quit_on_disconnect;
+	bool exit_on_disconnect;
 
 	struct wl_display* display;
 	struct wl_registry* registry;
@@ -1297,8 +1297,8 @@ static void client_destroy(void* obj)
 	nvnc_log(NVNC_LOG_DEBUG, "Client disconnected, new client count: %d",
 			wayvnc->nr_clients);
 
-	if (self->server->quit_on_disconnect && self->server->nr_clients == 0) {
-		self->server->do_exit = true;
+	if (self->server->exit_on_disconnect && self->server->nr_clients == 0) {
+		wayvnc_exit(wayvnc);
 	}
 
 	if (wayvnc->ctl) {
@@ -1725,7 +1725,7 @@ int main(int argc, char* argv[])
 	bool disable_input = false;
 	bool use_transient_seat = false;
 
-	bool quit_on_disconnect = false;
+	bool exit_on_disconnect = false;
 
 	int drm_fd MAYBE_UNUSED = -1;
 
@@ -1759,8 +1759,8 @@ int main(int argc, char* argv[])
 		  .default_ = "30" },
 		{ 'p', "performance", NULL,
 		  "Show performance counters." },
-		{ 'q', "quit", NULL,
-			"Quit on last client disconnect" },
+		{ 'e', "exit-on-disconnect", NULL,
+		  "Exit on last client disconnect." },
 		{ 'u', "unix-socket", NULL,
 		  "Create unix domain socket." },
 		{ 'd', "disable-input", NULL,
@@ -1803,7 +1803,7 @@ int main(int argc, char* argv[])
 	socket_path = option_parser_get_value(&option_parser, "socket");
 	overlay_cursor = !!option_parser_get_value(&option_parser, "render-cursor");
 	show_performance = !!option_parser_get_value(&option_parser, "performance");
-	quit_on_disconnect = !!option_parser_get_value(&option_parser, "quit");
+	exit_on_disconnect = !!option_parser_get_value(&option_parser, "exit-on-disconnect");
 	use_unix_socket = !!option_parser_get_value(&option_parser, "unix-socket");
 	use_websocket = !!option_parser_get_value(&option_parser, "websocket");
 	disable_input = !!option_parser_get_value(&option_parser, "disable-input");
@@ -1817,7 +1817,7 @@ int main(int argc, char* argv[])
 	start_detached = !!option_parser_get_value(&option_parser, "detached");
 
 	self.start_detached = start_detached;
-	self.quit_on_disconnect = quit_on_disconnect;
+	self.exit_on_disconnect = exit_on_disconnect;
 
 	keyboard_options = option_parser_get_value(&option_parser, "keyboard");
 	if (keyboard_options)

--- a/src/main.c
+++ b/src/main.c
@@ -84,6 +84,7 @@ enum socket_type {
 
 struct wayvnc {
 	bool do_exit;
+	bool quit_on_disconnect;
 
 	struct wl_display* display;
 	struct wl_registry* registry;
@@ -1296,6 +1297,10 @@ static void client_destroy(void* obj)
 	nvnc_log(NVNC_LOG_DEBUG, "Client disconnected, new client count: %d",
 			wayvnc->nr_clients);
 
+	if (self->server->quit_on_disconnect && self->server->nr_clients == 0) {
+		self->server->do_exit = true;
+	}
+
 	if (wayvnc->ctl) {
 		struct ctl_server_client_info info = {};
 		compose_client_info(self, &info);
@@ -1720,6 +1725,9 @@ int main(int argc, char* argv[])
 	bool disable_input = false;
 	bool use_transient_seat = false;
 
+	bool quit_on_disconnect = false;
+	bool first_client_connected = false;
+
 	int drm_fd MAYBE_UNUSED = -1;
 
 	int log_level = NVNC_LOG_WARNING;
@@ -1752,6 +1760,8 @@ int main(int argc, char* argv[])
 		  .default_ = "30" },
 		{ 'p', "performance", NULL,
 		  "Show performance counters." },
+		{ 'q', "quit", NULL,
+			"Quit on last client disconnect" },
 		{ 'u', "unix-socket", NULL,
 		  "Create unix domain socket." },
 		{ 'd', "disable-input", NULL,
@@ -1794,6 +1804,7 @@ int main(int argc, char* argv[])
 	socket_path = option_parser_get_value(&option_parser, "socket");
 	overlay_cursor = !!option_parser_get_value(&option_parser, "render-cursor");
 	show_performance = !!option_parser_get_value(&option_parser, "performance");
+	quit_on_disconnect = !!option_parser_get_value(&option_parser, "quit");
 	use_unix_socket = !!option_parser_get_value(&option_parser, "unix-socket");
 	use_websocket = !!option_parser_get_value(&option_parser, "websocket");
 	disable_input = !!option_parser_get_value(&option_parser, "disable-input");
@@ -1807,6 +1818,7 @@ int main(int argc, char* argv[])
 	start_detached = !!option_parser_get_value(&option_parser, "detached");
 
 	self.start_detached = start_detached;
+	self.quit_on_disconnect = quit_on_disconnect;
 
 	keyboard_options = option_parser_get_value(&option_parser, "keyboard");
 	if (keyboard_options)


### PR DESCRIPTION
I needed an option to automatically quit wayvnc when the last client disconnect.

Added a condition in client_destroy() and set self->server->do_exit to true, if condition is met.

For example, if wayvnc will only run intentionally by starting via SSH, it automatically
quit when I close the VNC connection and no other clients are connected.
