### PR TITLE
data-control: Ignore our own offers via custom MIME type

### DIFF
--- a/include/data-control.h
+++ b/include/data-control.h
@@ -28,7 +28,10 @@ struct data_control {
 	struct zwlr_data_control_source_v1* selection;
 	struct zwlr_data_control_source_v1* primary_selection;
 	struct zwlr_data_control_offer_v1* offer;
+	bool is_own_offer;
 	const char* mime_type;
+	/* x-wayvnc-client-(8 hexadecimal digits) + \0 */
+	char custom_mime_type_name[32];
 	char* cb_data;
 	size_t cb_len;
 };

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <time.h>
 #include <unistd.h>
 #include <assert.h>
 #include <inttypes.h>
@@ -2004,6 +2005,8 @@ int main(int argc, char* argv[])
 
 	self.disable_input = disable_input;
 	self.use_transient_seat = use_transient_seat;
+
+	srand(time(NULL));
 
 	struct aml* aml = aml_new();
 	if (!aml)


### PR DESCRIPTION
It behaves as intended when I tested. I don't think the custom MIME type will interfere with anything considering password managers add `x-kde-passwordManagerHint` and Chromium/Firefox add stuff too.

I have read and understood CONTRIBUTING.md.