### PR TITLE
data-control: Fix use-after-free in on_receive

### DIFF
--- a/include/data-control.h
+++ b/include/data-control.h
@@ -20,9 +20,16 @@
 
 #include "wlr-data-control-unstable-v1.h"
 
+#include "sys/queue.h"
+
+struct receive_context;
+
+LIST_HEAD(receive_context_list, receive_context);
+
 struct data_control {
 	struct wl_display* wl_display;
 	struct nvnc* server;
+	struct receive_context_list receive_contexts;
 	struct zwlr_data_control_manager_v1* manager;
 	struct zwlr_data_control_device_v1* device;
 	struct zwlr_data_control_source_v1* selection;

--- a/src/data-control.c
+++ b/src/data-control.c
@@ -29,7 +29,7 @@
 static const char custom_mime_type_data[] = "wayvnc";
 
 struct receive_context {
-	struct data_control* data_control;
+	struct nvnc* server;
 	struct aml_handler* handler;
 	LIST_ENTRY(receive_context) link;
 	struct zwlr_data_control_offer_v1* offer;
@@ -71,8 +71,7 @@ static void on_receive(void* handler)
 	ctx->mem_fp = NULL;
 
 	if (ctx->mem_size)
-		nvnc_send_cut_text(ctx->data_control->server, ctx->mem_data,
-				ctx->mem_size);
+		nvnc_send_cut_text(ctx->server, ctx->mem_data, ctx->mem_size);
 
 	destroy_receive_context(ctx);
 }
@@ -103,7 +102,7 @@ static void receive_data(void* data,
 	close(pipe_fd[1]);
 
 	ctx->fd = pipe_fd[0];
-	ctx->data_control = self;
+	ctx->server = self->server;
 	ctx->offer = offer;
 	ctx->mem_fp = open_memstream(&ctx->mem_data, &ctx->mem_size);
 	if (!ctx->mem_fp) {


### PR DESCRIPTION
If a client is closed between the time that one of its receive contexts is created and the time that the receive context is finished reading from its fd, when it is finished and finally calls nvnc_send_cut_text it will access ctx->data_control->server, but data_control is part of the wayvnc_client object which was freed when the client was closed.

The only purpose of the data_control pointer being in receive_context was to pass data_control->server to nvnc_send_cut_text, so receive_context can just store that server pointer itself.

This was the issue I found in https://github.com/any1/neatvnc/pull/114#issuecomment-2303229294
Can be reproduced by having a VNC client open, then `wl-copy < /some/obnoxiously/large/uncompressible/text` on the server and immediately closing the VNC client after running that command.
I have read and understood CONTRIBUTING.md.