### PR TITLE
buffer: Fix compilation without ENABLE_SCREENCOPY_DMABUF

### DIFF
--- a/include/buffer.h
+++ b/include/buffer.h
@@ -45,13 +45,13 @@ enum wv_buffer_domain {
 	WV_BUFFER_DOMAIN_CURSOR,
 };
 
-#ifdef ENABLE_SCREENCOPY_DMABUF
 struct wv_gbm_device {
+#ifdef ENABLE_SCREENCOPY_DMABUF
 	atomic_int ref;
-	struct gbm_device* dev;
 	int fd;
-};
 #endif
+	struct gbm_device* dev;
+};
 
 struct wv_buffer {
 	enum wv_buffer_type type;
@@ -104,9 +104,7 @@ struct wv_buffer_config {
 struct wv_buffer_pool {
 	struct wv_buffer_queue queue;
 	struct wv_buffer_config config;
-#ifdef ENABLE_SCREENCOPY_DMABUF
 	struct wv_gbm_device* gbm;
-#endif
 };
 
 enum wv_buffer_type wv_buffer_get_available_types(void);

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -598,13 +598,17 @@ static bool wv_buffer_pool_match_buffer(struct wv_buffer_pool* pool,
 	case WV_BUFFER_DMABUF:
 #endif
 		if (pool->config.width != buffer->width
-		    || pool->config.height != buffer->height
-		    || pool->config.format != buffer->format
-		    || pool->config.node != buffer->node
-		    || !modifiers_match(pool->config.modifiers,
-			    pool->config.n_modifiers, buffer->modifiers,
-			    buffer->n_modifiers))
+			|| pool->config.height != buffer->height
+			|| pool->config.format != buffer->format)
 			return false;
+
+#ifdef ENABLE_SCREENCOPY_DMABUF
+		if (pool->config.node != buffer->node
+			|| !modifiers_match(pool->config.modifiers,
+				pool->config.n_modifiers, buffer->modifiers,
+				buffer->n_modifiers))
+			return false;
+#endif
 
 		return true;
 	case WV_BUFFER_UNSPEC:


### PR DESCRIPTION
`wv_gbm_device` is used unconditionally in `buffer.c`, which breaks compilation. I exposed `wv_gbm_device` unconditionally and limit it's contents instead.