### PR TITLE
buffer: blind fix gbm_bo_create_with_modifiers2 for !HAVE_LINUX_DMA_HEAP

### DIFF
--- a/src/buffer.c
+++ b/src/buffer.c
@@ -307,7 +307,7 @@ static struct wv_buffer* wv_buffer_create_dmabuf(
 				config->modifiers, config->n_modifiers,
 				GBM_BO_USE_RENDERING);
 #else
-	self->bo = gbm_bo_create_with_modifiers2(gbm, config->width,
+	self->bo = gbm_bo_create_with_modifiers2(gbm->dev, config->width,
 			config->height, config->format, config->modifiers,
 			config->n_modifiers, GBM_BO_USE_RENDERING);
 #endif


### PR DESCRIPTION
Fixes #351