### PR TITLE
keyboard: Implement multiple layouts

### DIFF
--- a/include/keyboard.h
+++ b/include/keyboard.h
@@ -39,6 +39,8 @@ struct keyboard {
 	struct table_entry* lookup_table;
 
 	struct intset key_state;
+
+	int last_sent_group;
 };
 
 int keyboard_init(struct keyboard* self, const struct xkb_rule_names* rule_names);


### PR DESCRIPTION
This makes it possible to switch layouts using `XKB_DEFAULT_OPTIONS=grp:alt_shift_toggle` and will automatically try a different layout if symbol lookup fails.