### PR TITLE
client-resize: Stop rate_limiter timer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1234,6 +1234,11 @@ void on_output_dimension_change(struct output* output)
 
 	nvnc_log(NVNC_LOG_DEBUG, "Output dimensions changed. Restarting frame capturer...");
 
+	aml_stop(aml_get_default(), self->rate_limiter);
+	if (self->next_frame) {
+		nvnc_fb_unref(self->next_frame->nvnc_fb);
+		self->next_frame = NULL;
+	}
 	screencopy_stop(self->screencopy);
 	wayvnc_start_capture_immediate(self);
 }


### PR DESCRIPTION
A VNC client resize request can be received when the rate limiter timer is active. If the timer fires between on_output_dimension_change() calling wayvnc_start_capture_immediate() and the capture finishing, wayvnc_start_capture() is called with a capture already in progress.

This is fatal when the wlr_screencopy_unstable_v1 interface is being used, and results in a log as follows:-

```
DEBUG: ../src/main.c: 841: Client resolution changed: 1384x844, capturing output HEADLESS-1 which is headless: yes
TRACE: ../src/output-management.c: 269: reconfiguring output HEADLESS-1
TRACE: ../src/output-management.c: 284: applying new output config
DEBUG: ../subprojects/neatvnc/src/server.c: 1720: Client requested resize to 1384x844, result: 4
DEBUG: ../subprojects/neatvnc/src/server.c: 1675: Sending extended desktop resize rect: 1384x844
TRACE: ../src/output-management.c: 80: Got head current mode
TRACE: ../src/output-management.c: 164: Got new serial: 170
TRACE: ../src/output-management.c: 134: config request succeeded
DEBUG: ../src/main.c: 1235: Output dimensions changed. Restarting frame capturer...
DEBUG: ../src/buffer.c: 607: Reconfiguring buffer pool
TRACE: ../src/buffer.c: 394: wv_buffer_create: 1384x844, stride: 5536, format: 875713112
DEBUG: ../subprojects/neatvnc/src/server.c: 1675: Sending extended desktop resize rect: 1280x720
ERROR: ../src/main.c: 1176: Failed to start capture. Exiting...
Info: Exiting...
Info: Closing client connection 0x55ff05d86730
DEBUG: ../src/main.c: 1535: Client disconnected, new client count: 0
Info: Stopping screen capture
```

We found this when using `wayvnc` as a way to interface xrdp to a Wayland XFCE session. When xrdp connects to a VNC server, it requests a resize to the RDP client size. Consequently we've been issuing a lot of resize requests, which was how we came across this one.

We're using Debian 13 at the moment with labwc 0.8.3 to maximise compatibility., which is why we're using wlr_screencopy_unstable_v1

I have read and understood CONTRIBUTING.md.