### PR TITLE
doc: Update README (installation guide)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ project.
 
 #### For Arch Linux
 ```
-pacman -S base-devel libglvnd libxkbcommon pixman gnutls jansson
+sudo pacman -S base-devel libglvnd libxkbcommon pixman gnutls jansson
 ```
 
 #### For Fedora 37


### PR DESCRIPTION
Add sudo to Arch Linux installation command

The installation script cannot be run directly, unless it is being executed by the user as root.
