### PR TITLE
updated Arch dependencies, fixed gbm, mesa names

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,17 @@ project.
 
 #### For Arch Linux
 ```
-pacman -S base-devel libglvnd libxkbcommon pixman gnutls jansson
+pacman -S base-devel ffmpeg libxkbcommon mesa wayland git meson scdoc
 ```
+Also, see the PKGBUILD on the AUR.
 
 #### For Fedora 37
 ```
-dnf install -y meson gcc ninja-build pkg-config egl-wayland egl-wayland-devel \
-	mesa-libEGL-devel mesa-libEGL libwayland-egl libglvnd-devel \
-	libglvnd-core-devel libglvnd mesa-libGLES-devel mesa-libGLES \
-	libxkbcommon-devel libxkbcommon libwayland-client \
-	pam-devel pixman-devel libgbm-devel libdrm-devel scdoc \
+dnf install -y meson gcc ninja-build pkgconf-pkg-config egl-wayland \
+	egl-wayland-devel mesa-libEGL-devel mesa-libEGL libwayland-egl \
+	libglvnd-devel libglvnd-core-devel libglvnd mesa-libGLES-devel \
+	mesa-libGLES libxkbcommon-devel libxkbcommon libwayland-client \
+	pam-devel pixman-devel mesa-libgbm-devel libdrm-devel scdoc \
 	libavcodec-free-devel libavfilter-free-devel libavutil-free-devel \
 	turbojpeg-devel	wayland-devel gnutls-devel jansson-devel
 ```
@@ -57,8 +58,8 @@ apt build-dep wayvnc
 #### For Ubuntu
 ```
 apt install meson libdrm-dev libxkbcommon-dev libwlroots-dev libjansson-dev \
-	libpam0g-dev libgnutls28-dev libavfilter-dev libavcodec-dev \
-	libavutil-dev libturbojpeg0-dev scdoc
+	libgbm-dev libpam0g-dev libgnutls28-dev libavfilter-dev libavcodec-dev \
+	libavutil-dev libturbojpeg0-dev pkg-config scdoc
 ```
 
 #### Additional build-time dependencies


### PR DESCRIPTION
As discussed on irc, the dependencies in the `README.md` could use a work over.

The Arch Linux declared dependencies are reduced, due to some being included as dependencies of others. I've submitted a comment to the AUR package to reflect these changes. You can see that comment here:
https://aur.archlinux.org/packages/wayvnc-git#comment-1048282

The full name for the `libgbm` and `pkg-config` as offered by `dnf` on fedora have prefixes that get auto-fixed when being installed. I've added the prefix to avoid confusion.

Finally, `gbm.h` on Ubuntu is offered in the libgbm-dev. It is an optional dep, but the end user can easily see what would be needed if they desire to have that functionality.

The Arch dependencies are tested and fully complete. I did not look deeper into the `dnf` and `apt` dependencies, and as such there may still be some corrections that can be made.