### PR TITLE
Remove display from server on destroy

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -992,6 +992,8 @@ static void wayvnc_display_destroy(struct wayvnc_display* display)
 {
 	LIST_REMOVE(display, link);
 	wayvnc_display_detach(display);
+	if (display->wayvnc && display->wayvnc->nvnc)
+		nvnc_remove_display(display->wayvnc->nvnc, display->nvnc_display);
 	nvnc_display_unref(display->nvnc_display);
 	free(display);
 }


### PR DESCRIPTION
Found this on a Raspberry Pi where wayvnc starts in detached mode.

At startup, blank_screen() creates a placeholder display at 1280x720 (the hardcoded default). Later, wayland_attach() calls wayvnc_display_list_deinit + wayvnc_display_list_init, which destroys the old wayvnc_display wrapper but does not remove the nvnc_display from the server. The server then has two displays: the stale 1280x720 placeholder and the real 1920x1080 capture. Both get composited together, causing flickering gray rectangles in the top-left corner.

Fix: call nvnc_remove_display before nvnc_display_unref in wayvnc_display_destroy.

I have read and understood CONTRIBUTING.md.