### PR TITLE
man: Fix typo in private_key_file config docs

### DIFF
--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -158,7 +158,7 @@ considered to be part of the key or the value.
 *port*
 	The port to which the server shall bind. Default is 5900.
 
-*private_key_file_file*
+*private_key_file*
 	The path to the private key file for TLS encryption. Only applicable
 	when *enable_auth*=true.
 


### PR DESCRIPTION
The actual option is private_key_file, not private_key_file_file.

I have read and understood CONTRIBUTING.md.